### PR TITLE
fix: update travis matrix to node lts releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - 8
-  - 9
   - 10
+  - 12
 after_success:
   - npm run coverage


### PR DESCRIPTION
noticed this when looking into the graphql-tools issue, so why not fix it :man_shrugging: 

updates matrix to test current node lts releases/removes unsupported versions