### PR TITLE
Fix issue #78

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,11 +86,11 @@ const constraintDirectiveTypeDefs = `
     format: String
 
     # Number constraints
-    min: Int
-    max: Int
-    exclusiveMin: Int
-    exclusiveMax: Int
-    multipleOf: Int
+    min: Float
+    max: Float
+    exclusiveMin: Float
+    exclusiveMax: Float
+    multipleOf: Float
     uniqueTypeName: String
   ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION`
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,12 @@ function constraintDirective () {
       uniqueTypeName = directiveArgumentMap.uniqueTypeName.replace(/\W/g, '')
     } else {
       uniqueTypeName = `${fieldName}_${type.name}_${notNull ? 'NotNull_' : ''}` + Object.entries(directiveArgumentMap)
-        .map(([key, value]) => `${key}_${value.toString().replace(/\W/g, '')}`)
+        .map(([key, value]) => {
+          if (key === 'min' || key === 'max' || key === 'exclusiveMin' || key === 'exclusiveMax' || key === 'multipleOf') {
+            return `${key}_${value.toString().replace(/\W/g, 'dot')}`
+          }
+          return `${key}_${value.toString().replace(/\W/g, '')}`
+        })
         .join('_')
     }
     const key = Symbol.for(uniqueTypeName)

--- a/scalars/number.js
+++ b/scalars/number.js
@@ -30,15 +30,9 @@ module.exports = class ConstraintNumberType extends GraphQLScalarType {
   }
 }
 
-function modular (a, b) {
-  const [xa, xb] = a.toString().split('.')
-  const [ya, yb] = b.toString().split('.')
-  const za = typeof xb === 'string' ? xb.length : 0
-  const zb = typeof yb === 'string' ? yb.length : 0
-  const zLength = Math.max(za, zb)
-  const x = (xa + (xb || '')).concat('0'.repeat(zLength - za))
-  const y = (ya + (yb || '')).concat('0'.repeat(zLength - zb))
-  return parseInt(x, 10) % parseInt(y, 10)
+function divisible (a, b) {
+  const eps = Number.EPSILON * 3
+  return a % b < eps || a % b > b - eps
 }
 
 function validate (fieldName, args, value) {
@@ -64,7 +58,7 @@ function validate (fieldName, args, value) {
       [{ arg: 'exclusiveMax', value: args.exclusiveMax }])
   }
 
-  if (args.multipleOf !== undefined && modular(value, args.multipleOf) !== 0) {
+  if (args.multipleOf !== undefined && divisible(value, args.multipleOf) === false) {
     throw new ValidationError(fieldName,
       `Must be a multiple of ${args.multipleOf}`,
       [{ arg: 'multipleOf', value: args.multipleOf }])

--- a/scalars/number.js
+++ b/scalars/number.js
@@ -30,6 +30,17 @@ module.exports = class ConstraintNumberType extends GraphQLScalarType {
   }
 }
 
+function modular (a, b) {
+  const [xa, xb] = a.toString().split('.')
+  const [ya, yb] = b.toString().split('.')
+  const za = typeof xb === 'string' ? xb.length : 0
+  const zb = typeof yb === 'string' ? yb.length : 0
+  const zLength = Math.max(za, zb)
+  const x = (xa + (xb || '')).concat('0'.repeat(zLength - za))
+  const y = (ya + (yb || '')).concat('0'.repeat(zLength - zb))
+  return parseInt(x, 10) % parseInt(y, 10)
+}
+
 function validate (fieldName, args, value) {
   if (args.min !== undefined && value < args.min) {
     throw new ValidationError(fieldName,
@@ -53,7 +64,7 @@ function validate (fieldName, args, value) {
       [{ arg: 'exclusiveMax', value: args.exclusiveMax }])
   }
 
-  if (args.multipleOf !== undefined && value % args.multipleOf !== 0) {
+  if (args.multipleOf !== undefined && modular(value, args.multipleOf) !== 0) {
     throw new ValidationError(fieldName,
       `Must be a multiple of ${args.multipleOf}`,
       [{ arg: 'multipleOf', value: args.multipleOf }])

--- a/test/float.test.js
+++ b/test/float.test.js
@@ -1,0 +1,906 @@
+const { deepStrictEqual, strictEqual } = require('assert')
+const setup = require('./setup')
+const formatError = (error) => {
+  const { message, code, fieldName, context } = error.originalError
+
+  return { message, code, fieldName, context }
+}
+
+describe('@constraint Float in INPUT_FIELD_DEFINITION', function () {
+  const query = `mutation createBook($input: BookInput) {
+    createBook(input: $input) {
+      title
+    }
+  }`
+
+  describe('#min', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float! @constraint(min: 2.99)
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 3 } }
+        })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { createBook: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 2 } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value 2 at "input.title"; Expected type "title_Float_NotNull_min_2dot99". Must be at least 2.99')
+    })
+
+    it('should throw custom error', async function () {
+      const request = setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 2 } } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be at least 2.99',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'min', value: 2.99 }]
+      })
+    })
+  })
+
+  describe('#max', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float @constraint(max: 3.1)
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 2 } }
+        })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { createBook: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 4 } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value 4 at "input.title"; Expected type "title_Float_max_3dot1". Must be no greater than 3.1')
+    })
+
+    it('should throw custom error', async function () {
+      const request = setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 4 } } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be no greater than 3.1',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'max', value: 3.1 }]
+      })
+    })
+  })
+
+  describe('#exclusiveMin', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float! @constraint(exclusiveMin: 3)
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({
+          query, variables: { input: { title: 4.5 } }
+        })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { createBook: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({
+          query, variables: { input: { title: 3 } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value 3 at "input.title"; Expected type "title_Float_NotNull_exclusiveMin_3". Must be greater than 3')
+    })
+
+    it('should throw custom error', async function () {
+      const request = setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 3 } } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be greater than 3',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'exclusiveMin', value: 3 }]
+      })
+    })
+  })
+
+  describe('#exclusiveMax', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float! @constraint(exclusiveMax: 3)
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({
+          query, variables: { input: { title: 2 } }
+        })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { createBook: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({
+          query, variables: { input: { title: 3 } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value 3 at "input.title"; Expected type "title_Float_NotNull_exclusiveMax_3". Must be less than 3')
+    })
+
+    it('should throw custom error', async function () {
+      const request = setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 3 } } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be less than 3',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'exclusiveMax', value: 3 }]
+      })
+    })
+  })
+
+  describe('#multipleOf', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float! @constraint(multipleOf: 2.5)
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 12.5 } }
+        })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { createBook: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 7 } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value 7 at "input.title"; Expected type "title_Float_NotNull_multipleOf_2dot5". Must be a multiple of 2.5')
+    })
+
+    it('should throw custom error', async function () {
+      const request = setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 7 } } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be a multiple of 2.5',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'multipleOf', value: 2.5 }]
+      })
+    })
+  })
+
+  describe('#notNull', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float! @constraint(multipleOf: 2)
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should fail with null', async function () {
+      let { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: null } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value null at "input.title"; Expected non-nullable type "title_Float_NotNull_multipleOf_2!" not to be null.')
+    })
+
+    it('should fail with undefined', async function () {
+      let { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: undefined } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value {}; Field "title" of required type "title_Float_NotNull_multipleOf_2!" was not provided.')
+    })
+  })
+
+  describe('#uniqueTypeName', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: Float! @constraint(min: 3, uniqueTypeName: "BookInput_Title")
+      }`
+
+      this.request = setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 3 } }
+        })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { createBook: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 2 } }
+        })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$input" got invalid value 2 at "input.title"; Expected type "BookInput_Title". Must be at least 3')
+    })
+
+    it('should throw custom error', async function () {
+      const request = setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { input: { title: 2 } } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be at least 3',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'min', value: 3 }]
+      })
+    })
+  })
+})
+
+describe('@constraint Float in FIELD_DEFINITION', function () {
+  const query = `query {
+    books {
+      title
+    }
+  }`
+  const resolvers = function (data) {
+    return {
+      Query: {
+        books () {
+          return data
+        }
+      }
+    }
+  }
+
+  describe('#min', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(min: 2)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be at least 2')
+    })
+
+    it('should throw custom error', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be at least 2',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'min', value: 2 }]
+      })
+    })
+  })
+
+  describe('#min0', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(min: 0)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 1}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: -1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be at least 0')
+    })
+  })
+
+  describe('#max', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(max: 2)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be no greater than 2')
+    })
+
+    it('should throw custom error', async function () {
+      const mockData = [{title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be no greater than 2',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'max', value: 2 }]
+      })
+    })
+  })
+
+  describe('#max0', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(max: 0)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 0}, {title: -2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: -2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be no greater than 0')
+    })
+  })
+
+  describe('#exclusiveMin', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(exclusiveMin: 2)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 3}, {title: 4}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be greater than 2')
+    })
+
+    it('should throw custom error', async function () {
+      const mockData = [{title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be greater than 2',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'exclusiveMin', value: 2 }]
+      })
+    })
+  })
+
+  describe('#exclusiveMin0', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(exclusiveMin: 0)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 1}, {title: 4}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 0}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be greater than 0')
+    })
+  })
+
+  describe('#exclusiveMax', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(exclusiveMax: 2)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 0}, {title: 1}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be less than 2')
+    })
+
+    it('should throw custom error', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be less than 2',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'exclusiveMax', value: 2 }]
+      })
+    })
+  })
+
+  describe('#exclusiveMax0', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(exclusiveMax: 0)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: -1}, {title: -2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 0}, {title: -2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be less than 0')
+    })
+  })
+
+  describe('#multipleOf', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(multipleOf: 2)
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 2}, {title: 4}, {title: 6}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 1}, {title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be a multiple of 2')
+    })
+
+    it('should throw custom error', async function () {
+      const mockData = [{title: 1}, {title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be a multiple of 2',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'multipleOf', value: 2 }]
+      })
+    })
+  })
+
+  describe('#uniqueTypeName', function () {
+    before(function () {
+      this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: Float @constraint(min: 2, uniqueTypeName: "Book_Title")
+      }
+      `
+    })
+
+    it('should pass', async function () {
+      const mockData = [{title: 2}, {title: 3}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: mockData } })
+    })
+
+    it('should fail', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      strictEqual(body.errors[0].message, 'Must be at least 2')
+    })
+
+    it('should throw custom error', async function () {
+      const mockData = [{title: 1}, {title: 2}]
+      const request = setup(this.typeDefs, formatError, resolvers(mockData))
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be at least 2',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'title',
+        context: [{ arg: 'min', value: 2 }]
+      })
+    })
+  })
+})


### PR DESCRIPTION
[issue#78](https://github.com/confuser/graphql-constraint-directive/issues/78)


Number constraints

The types of min, max, exclusiveMin, exclusiveMax, and multipleOf were modified from Int to Float.

The name of the generated scalar was created by modifying the decimal point to dot to distinguish between the integer case and the real case. eg. id_Float_NotNull_min_2dot99