### PR TITLE
Allow directive to work on argument definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,11 +120,20 @@ function constraintDirective () {
 
           return fieldConfig
         }
+      },
+      [MapperKind.ARGUMENT]: (fieldConfig) => {
+        const directiveArgumentMap = getDirective(schema, fieldConfig, 'constraint')?.[0]
+
+        if (directiveArgumentMap) {
+          wrapType(fieldConfig, directiveArgumentMap)
+
+          return fieldConfig
+        }
       }
     })
 }
 
-const constraintDirectiveTypeDefs = `
+const constraintDirectiveTypeDefs = /* GraphQL */`
   directive @constraint(
     # String constraints
     minLength: Int
@@ -143,6 +152,6 @@ const constraintDirectiveTypeDefs = `
     exclusiveMax: Float
     multipleOf: Float
     uniqueTypeName: String
-  ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION`
+  ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION`
 
 module.exports = { constraintDirective, constraintDirectiveTypeDefs }

--- a/test/argument.test.js
+++ b/test/argument.test.js
@@ -1,0 +1,68 @@
+const { deepStrictEqual, strictEqual } = require('assert')
+const setup = require('./setup')
+const formatError = (error) => {
+  const { message, code, fieldName, context } = error?.originalError?.originalError || error?.originalError || error
+  return { message, code, fieldName, context }
+}
+
+describe('@constraint Int in ARGUMENT_DEFINITION', function () {
+  describe('#max', function () {
+    const query = /* GraphQL */`
+        query ($size: size_Int_max_3) {
+            books(size: $size) {
+                title
+            }
+        }
+    `
+
+    before(async function () {
+      this.typeDefs = /* GraphQL */`
+          type Query {
+              books (size: Int @constraint(max: 3)): [Book]
+          }
+          type Book {
+              title: String
+          }
+      `
+
+      this.request = await setup(this.typeDefs)
+    })
+
+    it('should pass', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { size: 2 } })
+
+      strictEqual(statusCode, 200)
+      deepStrictEqual(body, { data: { books: null } })
+    })
+
+    it('should fail', async function () {
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { size: 100 } })
+
+      strictEqual(statusCode, 400)
+      strictEqual(body.errors[0].message,
+        'Variable "$size" got invalid value 100; Expected type "size_Int_max_3". Must be no greater than 3')
+    })
+
+    it('should throw custom error', async function () {
+      const request = await setup(this.typeDefs, formatError)
+      const { body, statusCode } = await request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query, variables: { size: 100 } })
+
+      strictEqual(statusCode, 400)
+      deepStrictEqual(body.errors[0], {
+        message: 'Must be no greater than 3',
+        code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+        fieldName: 'size',
+        context: [{ arg: 'max', value: 3 }]
+      })
+    })
+  })
+})


### PR DESCRIPTION
Here is PR which should fix #11 by adding `ARGUMENT_DEFINITION` in directive and in mapSchema function.
Covered by couple of tests on int input variable.
