### PR TITLE
fix: array/list size validation for list of other scalar types

### DIFF
--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -186,6 +186,8 @@ function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, va
   // Validate array/list size
   const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, typeDefWithDirective.astNode)
 
+  let hasNonListValidation = false
+
   if (directiveArgumentMap) {
     let errMessageBase
 
@@ -205,6 +207,13 @@ function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, va
         errMessageBase + `must be no more than ${directiveArgumentMap.maxItems} in length`,
         [{ arg: 'maxItems', value: directiveArgumentMap.maxItems }]))
     }
+
+    for (const key in directiveArgumentMap) {
+      if (key !== 'maxItems' && key !== 'minItems') {
+        hasNonListValidation = true
+        break
+      }
+    }
   }
 
   // Validate array content
@@ -214,7 +223,7 @@ function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, va
 
       if (isInputObjectType(valueTypeDefArray)) {
         validateInputTypeValue(context, valueTypeDefArray, argName, variableName, element, currentField, iFieldNameFullIndexed)
-      } else {
+      } else if (hasNonListValidation) {
         const atMessage = ` at "${iFieldNameFullIndexed}"`
 
         validateScalarTypeValue(context, currentField, typeDefWithDirective, valueTypeDef, element, variableName, argName, iFieldNameFullIndexed, atMessage)

--- a/test/array-size.test.js
+++ b/test/array-size.test.js
@@ -3,7 +3,7 @@ const { valueByImplType, isStatusCodeError } = require('./testutils')
 
 module.exports.test = function (setup, implType) {
   describe('Array size', function () {
-    describe('Input object', function () {
+    describe('Inside Input Object', function () {
       const query = `mutation createBook($input: BookInput) {
         createBook(input: $input) {
           title
@@ -126,7 +126,7 @@ module.exports.test = function (setup, implType) {
       })
     })
 
-    describe('Input argument', function () {
+    describe('Scalar argument', function () {
       describe('#minItems', function () {
         before(async function () {
           this.typeDefs = `
@@ -209,7 +209,7 @@ module.exports.test = function (setup, implType) {
             title: String
           }
           type Mutation {
-            createBook(input: [Int] @constraint(maxItems: 2)): Book
+            createBook(input: [Int] @constraint(maxItems: 2, max: 100)): Book
           }`
 
           this.request = await setup(this.typeDefs)
@@ -260,11 +260,168 @@ module.exports.test = function (setup, implType) {
             .send({ query })
 
           isStatusCodeError(statusCode, implType)
+          strictEqual(body.errors.length, 1)
           strictEqual(
             body.errors[0].message,
             'Argument "input" of "createBook"' +
             valueByImplType(implType, '; Expected type "title_List_Int_NotNull_max_3"') +
             ' must be no more than 2 in length'
+          )
+        })
+
+        it('should fail - another scalar validation', async function () {
+          const query = `mutation createBook {
+            createBook(input: [2, 101]) {
+              title
+            }
+          }`
+
+          const { body, statusCode } = await this.request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query })
+
+          isStatusCodeError(statusCode, implType)
+          strictEqual(body.errors.length, 1)
+          strictEqual(
+            body.errors[0].message,
+            'Argument "input" of "createBook" got invalid value 101 at "[1]"' +
+            valueByImplType(implType, '; Expected type "title_List_Int_NotNull_max_3"') +
+            '. Must be no greater than 100'
+          )
+        })
+      })
+    })
+
+    describe('Scalar argument of ID type', function () {
+      describe('#minItems', function () {
+        before(async function () {
+          this.typeDefs = `
+          type Query {
+            books: [Book]
+          }
+          type Book {
+            title: String
+          }
+          type Mutation {
+            createBook(input: [ID]! @constraint(minItems: 3)): Book
+          }`
+
+          this.request = await setup(this.typeDefs)
+        })
+
+        it('should pass', async function () {
+          const query = `mutation createBook {
+            createBook(input: ["2","3","4"]) {
+              title
+            }
+          }`
+          const { body, statusCode } = await this.request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query })
+
+          strictEqual(statusCode, 200)
+          deepStrictEqual(body, { data: { createBook: null } })
+        })
+
+        it('should fail', async function () {
+          const query = `mutation createBook {
+            createBook(input: ["2","3"]) {
+              title
+            }
+          }`
+          const { body, statusCode } = await this.request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query })
+
+          isStatusCodeError(statusCode, implType)
+          strictEqual(body.errors.length, 1)
+          strictEqual(
+            body.errors[0].message,
+            'Argument "input" of "createBook"' +
+            valueByImplType(implType, '; Expected type "title_List_ListNotNull_Int_NotNull_min_3"') +
+            ' must be at least 3 in length'
+          )
+        })
+      })
+    })
+
+    describe('InputObject argument', function () {
+      describe('#minItems', function () {
+        before(async function () {
+          this.typeDefs = `
+          type Query {
+            books: [Book]
+          }
+          type Book {
+            title: String
+          }
+          type Mutation {
+            createBook(input: [BookInput]! @constraint(minItems: 3)): Book
+          }
+          input BookInput {
+            title: String @constraint(maxLength: 2)
+          }
+          `
+          this.request = await setup(this.typeDefs)
+        })
+
+        it('should pass', async function () {
+          const query = `mutation createBook {
+            createBook(input: [{title:"aa"},{title:"ab"},{title:"ba"}]) {
+              title
+            }
+          }`
+          const { body, statusCode } = await this.request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query })
+
+          strictEqual(statusCode, 200)
+          deepStrictEqual(body, { data: { createBook: null } })
+        })
+
+        it('should fail', async function () {
+          const query = `mutation createBook {
+            createBook(input: [{title:"aa"},{title:"ab"}]) {
+              title
+            }
+          }`
+          const { body, statusCode } = await this.request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query })
+
+          isStatusCodeError(statusCode, implType)
+          strictEqual(body.errors.length, 1)
+          strictEqual(
+            body.errors[0].message,
+            'Argument "input" of "createBook"' +
+            valueByImplType(implType, '; Expected type "title_List_ListNotNull_Int_NotNull_min_3"') +
+            ' must be at least 3 in length'
+          )
+        })
+
+        it('should fail - another validation in input object', async function () {
+          const query = `mutation createBook {
+            createBook(input: [{title:"aa"},{title:"abc"},{title:"as"}]) {
+              title
+            }
+          }`
+          const { body, statusCode } = await this.request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query })
+
+          isStatusCodeError(statusCode, implType)
+          strictEqual(body.errors.length, 1)
+          strictEqual(
+            body.errors[0].message,
+            'Argument "input" of "createBook" got invalid value "abc" at "[1].title"' +
+            valueByImplType(implType, '; Expected type "title_List_ListNotNull_Int_NotNull_min_3"') +
+            '. Must be no more than 2 characters in length'
           )
         })
       })


### PR DESCRIPTION
This PR fixes array/list size validation to work for list of other scalar types (ID, Boolean)