### PR TITLE
fix: survive missing astNode

### DIFF
--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -148,6 +148,8 @@ module.exports = class QueryValidationVisitor {
 }
 
 function validateScalarTypeValue (context, currentQueryField, typeDefWithDirective, valueTypeDef, value, variableName, argName, fieldNameForError, errMessageAt) {
+  if (!typeDefWithDirective.astNode) return
+
   const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, typeDefWithDirective.astNode)
 
   if (directiveArgumentMap) {
@@ -175,6 +177,8 @@ function validateInputTypeValue (context, inputObjectTypeDef, argName, variableN
   // use new visitor to traverse input object structure
   const visitor = new InputObjectValidationVisitor(context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames)
 
+  if (!inputObjectTypeDef.astNode) return
+
   visit(inputObjectTypeDef.astNode, visitor)
 }
 
@@ -182,6 +186,8 @@ function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, va
   let valueTypeDefArray = valueTypeDef.ofType
 
   if (isNonNullType(valueTypeDefArray)) valueTypeDefArray = valueTypeDefArray.ofType
+
+  if (!typeDefWithDirective.astNode) return
 
   // Validate array/list size
   const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, typeDefWithDirective.astNode)


### PR DESCRIPTION
I'm not sure why, but we face error with missing `astNode` in some cases (even Query is perfectly valid). It's maybe because of GraphQL Mesh, but I was unable to reproduce this problem in this project. Anyway, adding some sanity checks.