### PR TITLE
fix: createApolloQueryValidationPlugin typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import {GraphQLSchema, GraphQLError, DocumentNode, ValidationContext} from "graphql";
+import {PluginDefinition} from "apollo-server-core";
 import QueryValidationVisitor from "./lib/query-validation-visitor";
 
 export function constraintDirective () : (schema: GraphQLSchema) => GraphQLSchema;
@@ -7,7 +8,7 @@ export const constraintDirectiveTypeDefs: string
 
 export function validateQuery () : (schema: GraphQLSchema, query: DocumentNode, variables: Record<string, any>, operationName?: string) => Array<GraphQLError>;
 
-export function createApolloQueryValidationPlugin () : (schema: GraphQLSchema) => function;
+export function createApolloQueryValidationPlugin ( options: { schema: GraphQLSchema } ) : PluginDefinition;
 
 export function createQueryValidationRule( options: { [key: string]: any }) : (context: ValidationContext) => QueryValidationVisitor;
 


### PR DESCRIPTION
fixes https://github.com/confuser/graphql-constraint-directive/issues/107
`createApolloQueryValidationPlugin` typing definition to match the implementation