### PR TITLE
#145 - server plugins based validation fails when dynamic argument used

### DIFF
--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -148,6 +148,8 @@ module.exports = class QueryValidationVisitor {
 }
 
 function validateScalarTypeValue (context, currentQueryField, typeDefWithDirective, valueTypeDef, value, variableName, argName, fieldNameForError, errMessageAt) {
+  if (!typeDefWithDirective.astNode) { return }
+
   const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, typeDefWithDirective.astNode)
 
   if (directiveArgumentMap) {
@@ -172,6 +174,8 @@ function validateScalarTypeValue (context, currentQueryField, typeDefWithDirecti
 }
 
 function validateInputTypeValue (context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames) {
+  if (!inputObjectTypeDef.astNode) { return }
+
   // use new visitor to traverse input object structure
   const visitor = new InputObjectValidationVisitor(context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames)
 
@@ -179,6 +183,8 @@ function validateInputTypeValue (context, inputObjectTypeDef, argName, variableN
 }
 
 function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, value, currentField, argName, variableName, iFieldNameFull) {
+  if (!typeDefWithDirective.astNode) { return }
+
   let valueTypeDefArray = valueTypeDef.ofType
 
   if (isNonNullType(valueTypeDefArray)) valueTypeDefArray = valueTypeDefArray.ofType

--- a/test/argument-dynamic.test.js
+++ b/test/argument-dynamic.test.js
@@ -1,0 +1,52 @@
+const { strictEqual } = require('assert')
+const { GraphQLString } = require('graphql')
+const { mapSchema, getDirective, MapperKind } = require('@graphql-tools/utils')
+
+const dateDirectiveTypeDefs = 'directive @formatDate on FIELD_DEFINITION'
+
+const dateDirectiveTransformer = (schema) =>
+  mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD] (fieldConfig) {
+      const dateDirective = getDirective(schema, fieldConfig, 'formatDate')?.[0]
+      if (dateDirective) {
+        fieldConfig.args.format = {
+          type: GraphQLString
+        }
+
+        fieldConfig.type = GraphQLString
+        return fieldConfig
+      }
+    }
+  })
+
+module.exports.test = function (setup, implType) {
+  describe('Dynamic argument', function () {
+    before(async function () {
+      this.typeDefs = /* GraphQL */`
+        type Query {
+            getBook: String @formatDate
+            getBooks: [String] @formatDate
+        }
+      ` + '\n' + dateDirectiveTypeDefs
+
+      this.request = await setup({ typeDefs: this.typeDefs, schemaCreatedCallback: (schema) => { return dateDirectiveTransformer(schema) } })
+    })
+
+    it('should pass', async function () {
+      const query = /* GraphQL */`
+          query Go {
+            getBook(format: "aa")
+            getBooks(format: "aa")
+          }
+
+        `
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      if (statusCode !== 200) { console.log(body) }
+      strictEqual(statusCode, 200)
+    })
+  })
+}

--- a/test/argument.test.js
+++ b/test/argument.test.js
@@ -44,7 +44,7 @@ module.exports.test = function (setup, implType) {
               authors (size: Int @constraint(max: 4)): [String]
           }
         `
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -105,7 +105,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -183,7 +183,7 @@ module.exports.test = function (setup, implType) {
           }
         `
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -257,7 +257,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')

--- a/test/array-size.test.js
+++ b/test/array-size.test.js
@@ -26,7 +26,7 @@ module.exports.test = function (setup, implType) {
             title: [Int!] @constraint(minItems: 3)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -86,7 +86,7 @@ module.exports.test = function (setup, implType) {
             title: [Int!] @constraint(maxItems: 2)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -140,7 +140,7 @@ module.exports.test = function (setup, implType) {
             createBook(input: [Int] @constraint(minItems: 3)): Book
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -212,7 +212,7 @@ module.exports.test = function (setup, implType) {
             createBook(input: [Int] @constraint(maxItems: 2, max: 100)): Book
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -307,7 +307,7 @@ module.exports.test = function (setup, implType) {
             createBook(input: [ID]! @constraint(minItems: 3)): Book
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -365,7 +365,7 @@ module.exports.test = function (setup, implType) {
             title: String @constraint(maxLength: 2)
           }
           `
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {

--- a/test/array-structures.test.js
+++ b/test/array-structures.test.js
@@ -29,7 +29,7 @@ module.exports.test = function (setup, implType) {
             }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -79,7 +79,7 @@ module.exports.test = function (setup, implType) {
           }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -142,7 +142,7 @@ module.exports.test = function (setup, implType) {
           }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -221,7 +221,7 @@ module.exports.test = function (setup, implType) {
           }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -264,7 +264,7 @@ module.exports.test = function (setup, implType) {
           }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -330,7 +330,7 @@ module.exports.test = function (setup, implType) {
           }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -381,7 +381,7 @@ module.exports.test = function (setup, implType) {
           }
           `
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -26,7 +26,7 @@ module.exports.test = function (setup, implType) {
             title: [Int!]! @constraint(min: 3)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -70,7 +70,7 @@ module.exports.test = function (setup, implType) {
             title: [Int!] @constraint(max: 3)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -115,7 +115,7 @@ module.exports.test = function (setup, implType) {
             title: [Int!] @constraint(multipleOf: 2)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         if (!isServerValidatorEnvelop(implType)) {
@@ -174,7 +174,7 @@ module.exports.test = function (setup, implType) {
             title: [String!] @constraint(minLength: 3)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -219,7 +219,7 @@ module.exports.test = function (setup, implType) {
             title: [String] @constraint(maxLength: 3)
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -264,7 +264,7 @@ module.exports.test = function (setup, implType) {
             title: [String!]! @constraint(format: "uri")
           }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {

--- a/test/float.test.js
+++ b/test/float.test.js
@@ -26,7 +26,7 @@ module.exports.test = function (setup, implType) {
         title: Float! @constraint(min: 2.99)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -52,7 +52,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -85,7 +85,7 @@ module.exports.test = function (setup, implType) {
         title: Float @constraint(max: 3.1)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -111,7 +111,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -144,7 +144,7 @@ module.exports.test = function (setup, implType) {
         title: Float! @constraint(exclusiveMin: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -174,7 +174,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -207,7 +207,7 @@ module.exports.test = function (setup, implType) {
         title: Float! @constraint(exclusiveMax: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -237,7 +237,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -270,7 +270,7 @@ module.exports.test = function (setup, implType) {
         title: Float! @constraint(multipleOf: 2.5)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -296,7 +296,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -329,7 +329,7 @@ module.exports.test = function (setup, implType) {
         title: Float! @constraint(multipleOf: 2)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       if (!isServerValidatorEnvelop(implType)) {
@@ -373,7 +373,7 @@ module.exports.test = function (setup, implType) {
         title: Float @constraint(multipleOf: 2)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass with null', async function () {
@@ -413,7 +413,7 @@ module.exports.test = function (setup, implType) {
         title: Float! @constraint(min: 3, uniqueTypeName: "BookInput_Title")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
       if (isSchemaWrapperImplType(implType)) {
         it('should pass', async function () {
@@ -438,7 +438,7 @@ module.exports.test = function (setup, implType) {
         })
 
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -487,7 +487,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -499,7 +499,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -511,7 +511,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -541,7 +541,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 1 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -553,7 +553,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: -1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -578,7 +578,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -590,7 +590,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -602,7 +602,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -632,7 +632,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 0 }, { title: -2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -644,7 +644,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: -2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -669,7 +669,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 3 }, { title: 4 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -681,7 +681,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -693,7 +693,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -723,7 +723,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 1 }, { title: 4 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -735,7 +735,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 0 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -760,7 +760,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 0 }, { title: 1 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -772,7 +772,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -784,7 +784,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -814,7 +814,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: -1 }, { title: -2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -826,7 +826,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 0 }, { title: -2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -851,7 +851,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 2 }, { title: 4 }, { title: 6 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -863,7 +863,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -875,7 +875,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -905,7 +905,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -917,7 +917,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -929,7 +929,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')

--- a/test/fragment-inline.test.js
+++ b/test/fragment-inline.test.js
@@ -19,7 +19,7 @@ module.exports.test = function (setup, implType) {
         union Result = Book | Magazine
       `
 
-      this.request = await setup(this.typeDefs)
+      this.request = await setup({ typeDefs: this.typeDefs })
     })
 
     describe('Inlined value', function () {

--- a/test/fragment.test.js
+++ b/test/fragment.test.js
@@ -14,7 +14,7 @@ module.exports.test = function (setup, implType) {
         }
       `
 
-      this.request = await setup(this.typeDefs)
+      this.request = await setup({ typeDefs: this.typeDefs })
     })
 
     describe('Inlined value', function () {

--- a/test/input-object.test.js
+++ b/test/input-object.test.js
@@ -23,7 +23,7 @@ module.exports.test = function (setup, implType) {
         }
       `
 
-      this.request = await setup(this.typeDefs)
+      this.request = await setup({ typeDefs: this.typeDefs })
     })
 
     describe('Values provided over variables', function () {
@@ -82,7 +82,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -169,7 +169,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')

--- a/test/int.test.js
+++ b/test/int.test.js
@@ -25,7 +25,7 @@ module.exports.test = function (setup, implType) {
         title: Int! @constraint(min: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -51,7 +51,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -84,7 +84,7 @@ module.exports.test = function (setup, implType) {
         title: Int @constraint(max: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -110,7 +110,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -143,7 +143,7 @@ module.exports.test = function (setup, implType) {
         title: Int! @constraint(exclusiveMin: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -173,7 +173,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -206,7 +206,7 @@ module.exports.test = function (setup, implType) {
         title: Int! @constraint(exclusiveMax: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -236,7 +236,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -269,7 +269,7 @@ module.exports.test = function (setup, implType) {
         title: Int! @constraint(multipleOf: 2)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -295,7 +295,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -328,7 +328,7 @@ module.exports.test = function (setup, implType) {
         title: Int! @constraint(multipleOf: 2)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       if (!isServerValidatorEnvelop(implType)) {
@@ -372,7 +372,7 @@ module.exports.test = function (setup, implType) {
         title: Int @constraint(multipleOf: 2)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass with null', async function () {
@@ -412,7 +412,7 @@ module.exports.test = function (setup, implType) {
         title: Int! @constraint(min: 3, uniqueTypeName: "BookInput_Title")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       if (isSchemaWrapperImplType(implType)) {
@@ -438,7 +438,7 @@ module.exports.test = function (setup, implType) {
         })
 
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -487,7 +487,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -499,7 +499,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -511,7 +511,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -541,7 +541,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 1 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -553,7 +553,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: -1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -578,7 +578,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -590,7 +590,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -602,7 +602,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -632,7 +632,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 0 }, { title: -2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -644,7 +644,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: -2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -669,7 +669,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 3 }, { title: 4 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -681,7 +681,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -693,7 +693,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -723,7 +723,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 1 }, { title: 4 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -735,7 +735,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 0 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -760,7 +760,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 0 }, { title: 1 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -772,7 +772,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -784,7 +784,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -814,7 +814,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: -1 }, { title: -2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -826,7 +826,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 0 }, { title: -2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -851,7 +851,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 2 }, { title: 4 }, { title: 6 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -863,7 +863,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -875,7 +875,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -905,7 +905,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 2 }, { title: 3 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -917,7 +917,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -929,7 +929,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 1 }, { title: 2 }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -20,7 +20,7 @@ module.exports.test = function (setup, implType) {
       subTitle: Int! @constraint(max: 3, uniqueTypeName: "BookInput_subTitle")
     }`
 
-      this.request = await setup(this.typeDefs)
+      this.request = await setup({ typeDefs: this.typeDefs })
     })
 
     it('should allow introspection', async function () {

--- a/test/setup-apollo-plugin.js
+++ b/test/setup-apollo-plugin.js
@@ -4,11 +4,15 @@ const { makeExecutableSchema } = require('@graphql-tools/schema')
 const request = require('supertest')
 const { createApolloQueryValidationPlugin, constraintDirectiveTypeDefs } = require('..')
 
-module.exports = async function (typeDefs, formatError, resolvers) {
-  const schema = makeExecutableSchema({
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+  let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
   })
+
+  if (schemaCreatedCallback) {
+    schema = schemaCreatedCallback(schema)
+  }
 
   const plugins = [
     createApolloQueryValidationPlugin({

--- a/test/setup-envelop-plugin.js
+++ b/test/setup-envelop-plugin.js
@@ -4,11 +4,15 @@ const { createServer } = require('@graphql-yoga/node')
 const request = require('supertest')
 const { createEnvelopQueryValidationPlugin, constraintDirectiveTypeDefs } = require('..')
 
-module.exports = async function (typeDefs, formatError, resolvers) {
-  const schema = makeExecutableSchema({
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+  let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
   })
+
+  if (schemaCreatedCallback) {
+    schema = schemaCreatedCallback(schema)
+  }
 
   const app = express()
   const yoga = createServer({

--- a/test/setup-schema-wrapper.js
+++ b/test/setup-schema-wrapper.js
@@ -4,11 +4,15 @@ const { makeExecutableSchema } = require('@graphql-tools/schema')
 const request = require('supertest')
 const { constraintDirectiveTypeDefs, constraintDirective } = require('..')
 
-module.exports = async function (typeDefs, formatError, resolvers) {
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
   let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
   })
+
+  if (schemaCreatedCallback) {
+    schema = schemaCreatedCallback(schema)
+  }
 
   schema = constraintDirective()(schema)
 

--- a/test/setup-validation-rule-express-graphql.js
+++ b/test/setup-validation-rule-express-graphql.js
@@ -4,11 +4,15 @@ const { makeExecutableSchema } = require('@graphql-tools/schema')
 const request = require('supertest')
 const { createQueryValidationRule, constraintDirectiveTypeDefs } = require('..')
 
-module.exports = async function (typeDefs, formatError, resolvers) {
-  const schema = makeExecutableSchema({
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+  let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
   })
+
+  if (schemaCreatedCallback) {
+    schema = schemaCreatedCallback(schema)
+  }
 
   const app = express()
 

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -25,7 +25,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(minLength: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -62,7 +62,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -95,7 +95,7 @@ module.exports.test = function (setup, implType) {
         title: String @constraint(maxLength: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -121,7 +121,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -154,7 +154,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(startsWith: "💩")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -180,7 +180,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -213,7 +213,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(endsWith: "💩")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -239,7 +239,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -272,7 +272,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(contains: "💩")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -298,7 +298,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -331,7 +331,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(notContains: "foo")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -357,7 +357,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -390,7 +390,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(pattern: "^[0-9a-zA-Z]*$")
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -416,7 +416,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -450,7 +450,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "byte")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -480,7 +480,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -513,7 +513,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "date-time")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -543,7 +543,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -576,7 +576,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "date")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -606,7 +606,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -639,7 +639,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "email")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -669,7 +669,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -702,7 +702,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "ipv4")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -732,7 +732,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -765,7 +765,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "ipv6")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -795,7 +795,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -828,7 +828,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "uri")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -858,7 +858,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -891,7 +891,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "uuid")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -921,7 +921,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -954,7 +954,7 @@ module.exports.test = function (setup, implType) {
           title: String! @constraint(format: "test")
         }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should fail', async function () {
@@ -972,7 +972,7 @@ module.exports.test = function (setup, implType) {
 
         if (isSchemaWrapperImplType(implType)) {
           it('should throw custom error', async function () {
-            const request = await setup(this.typeDefs, formatError)
+            const request = await setup({ typeDefs: this.typeDefs, formatError })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1006,7 +1006,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(minLength: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       if (!isServerValidatorEnvelop(implType)) {
@@ -1051,7 +1051,7 @@ module.exports.test = function (setup, implType) {
         title: String @constraint(minLength: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass with null', async function () {
@@ -1097,7 +1097,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(minLength: 3)
       }`
 
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {
@@ -1123,7 +1123,7 @@ module.exports.test = function (setup, implType) {
 
       if (isSchemaWrapperImplType(implType)) {
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1157,7 +1157,7 @@ module.exports.test = function (setup, implType) {
         title: String! @constraint(minLength: 3, uniqueTypeName: "BookInput_Title")
       }`
 
-          this.request = await setup(this.typeDefs)
+          this.request = await setup({ typeDefs: this.typeDefs })
         })
 
         it('should pass', async function () {
@@ -1182,7 +1182,7 @@ module.exports.test = function (setup, implType) {
         })
 
         it('should throw custom error', async function () {
-          const request = await setup(this.typeDefs, formatError)
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1230,7 +1230,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'foo' }, { title: 'foobar' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1242,7 +1242,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 'fo' }, { title: 'foo' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1254,7 +1254,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 'fo' }, { title: 'foo' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1283,7 +1283,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'fo' }, { title: 'foo' }, { title: 'bar' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1295,7 +1295,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 'foo' }, { title: 'foobar' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1307,7 +1307,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 'foo' }, { title: 'foobar' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1336,7 +1336,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: '💩foo' }, { title: '💩bar' }, { title: '💩baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1348,7 +1348,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: '💩foo' }, { title: '💩bar' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1360,7 +1360,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: '💩foo' }, { title: '💩bar' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1389,7 +1389,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'foo💩' }, { title: 'bar💩' }, { title: 'baz💩' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1401,7 +1401,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 'foo💩' }, { title: 'bar💩' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1413,7 +1413,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 'foo💩' }, { title: 'bar💩' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1442,7 +1442,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'foo💩foo' }, { title: 'bar💩bar' }, { title: 'baz💩baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1454,7 +1454,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 'foo💩foo' }, { title: 'bar💩bar' }, { title: 'bazbaz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1466,7 +1466,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 'foo💩foo' }, { title: 'bar💩bar' }, { title: 'bazbaz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1495,7 +1495,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'foo' }, { title: 'bar' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1507,7 +1507,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 'foo💩foo' }, { title: 'barr' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1519,7 +1519,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 'foo💩foo' }, { title: 'barr' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1548,7 +1548,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'foo' }, { title: 'bar' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1560,7 +1560,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: '💩' }, { title: '£££' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1572,7 +1572,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: '💩' }, { title: '£££' }, { title: 'baz' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -1602,7 +1602,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: 'afoo' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1614,7 +1614,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: '£££' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1626,7 +1626,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: '£££' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1655,7 +1655,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: '2018-05-16T12:57:00Z' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1667,7 +1667,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: '2018-05-1612:57:00Z' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1679,7 +1679,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: '2018-05-1612:57:00Z' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1708,7 +1708,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: '2018-05-16' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1720,7 +1720,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1732,7 +1732,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1761,7 +1761,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: 'test@test.com' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1773,7 +1773,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: 'testtest.com' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1785,7 +1785,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: 'testtest.com' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1814,7 +1814,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: '127.0.0.1' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1826,7 +1826,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: '256.256.256.256' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1838,7 +1838,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: '256.256.256.256' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1867,7 +1867,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: '2001:db8:0000:1:1:1:1:1' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1879,7 +1879,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1891,7 +1891,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1920,7 +1920,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: 'foobar.com' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1932,7 +1932,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1944,7 +1944,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1973,7 +1973,7 @@ module.exports.test = function (setup, implType) {
 
           it('should pass', async function () {
             const mockData = [{ title: 'A987FBC9-4BED-3078-CF07-9141BA07C9F3' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1985,7 +1985,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -1997,7 +1997,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -2026,7 +2026,7 @@ module.exports.test = function (setup, implType) {
 
           it('should fail', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -2038,7 +2038,7 @@ module.exports.test = function (setup, implType) {
 
           it('should throw custom error', async function () {
             const mockData = [{ title: 'a' }]
-            const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+            const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
             const { body, statusCode } = await request
               .post('/graphql')
               .set('Accept', 'application/json')
@@ -2068,7 +2068,7 @@ module.exports.test = function (setup, implType) {
 
         it('should pass', async function () {
           const mockData = [{ title: 'foo' }, { title: 'foobar' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -2080,7 +2080,7 @@ module.exports.test = function (setup, implType) {
 
         it('should fail', async function () {
           const mockData = [{ title: 'fo' }, { title: 'foo' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')
@@ -2092,7 +2092,7 @@ module.exports.test = function (setup, implType) {
 
         it('should throw custom error', async function () {
           const mockData = [{ title: 'fo' }, { title: 'foo' }]
-          const request = await setup(this.typeDefs, formatError, resolvers(mockData))
+          const request = await setup({ typeDefs: this.typeDefs, formatError, resolvers: resolvers(mockData) })
           const { body, statusCode } = await request
             .post('/graphql')
             .set('Accept', 'application/json')

--- a/test/testsuite-apollo-plugin.js
+++ b/test/testsuite-apollo-plugin.js
@@ -16,4 +16,5 @@ describe('Server validator based implementation - Apollo plugin', function () {
   require('./float.test').test(setup, IMPL_TYPE)
   require('./int.test').test(setup, IMPL_TYPE)
   require('./string.test').test(setup, IMPL_TYPE)
+  require('./argument-dynamic.test').test(setup, IMPL_TYPE)
 })

--- a/test/testsuite-envelop-plugin.js
+++ b/test/testsuite-envelop-plugin.js
@@ -16,4 +16,5 @@ describe('Server validator based implementation - Envelop plugin', function () {
   require('./float.test').test(setup, IMPL_TYPE)
   require('./int.test').test(setup, IMPL_TYPE)
   require('./string.test').test(setup, IMPL_TYPE)
+  require('./argument-dynamic.test').test(setup, IMPL_TYPE)
 })

--- a/test/testsuite-schema-wrapper.js
+++ b/test/testsuite-schema-wrapper.js
@@ -15,4 +15,5 @@ describe('Schema wrapper based implementation', function () {
   require('./float.test').test(setup, IMPL_TYPE)
   require('./int.test').test(setup, IMPL_TYPE)
   require('./string.test').test(setup, IMPL_TYPE)
+  require('./argument-dynamic.test').test(setup, IMPL_TYPE)
 })

--- a/test/testsuite-validation-rule-express-graphql.js
+++ b/test/testsuite-validation-rule-express-graphql.js
@@ -16,4 +16,5 @@ describe('Server validator based implementation - validation rule - Server Graph
   require('./float.test').test(setup, IMPL_TYPE)
   require('./int.test').test(setup, IMPL_TYPE)
   require('./string.test').test(setup, IMPL_TYPE)
+  require('./argument-dynamic.test').test(setup, IMPL_TYPE)
 })

--- a/test/variable.test.js
+++ b/test/variable.test.js
@@ -15,7 +15,7 @@ module.exports.test = function (setup, implType) {
               title: String
           }
         `
-        this.request = await setup(this.typeDefs)
+        this.request = await setup({ typeDefs: this.typeDefs })
       })
 
       it('should pass', async function () {


### PR DESCRIPTION
I was able to reproduce bug #145 and patch it.
Also sanitized other two places with potential for similar problem, even no test exists to break them.
Test setup method signature had to be changed to allow optional parameters.