### PR TITLE
Schema documentation transformation - #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,83 @@ app.use(
 app.listen(4000);
 
 ```
+### Schema documentation
+
+You can use provided schema transformation to automatically add `@constraint` documentation into fields and arguments descriptions,
+so clients/users know them, as directive itself is typically not present in the exposed schema.
+
+```js
+const { constraintDirectiveTypeDefs, constraintDirectiveDocumentation } = require('graphql-constraint-directive')
+const { makeExecutableSchema } = require('@graphql-tools/schema')
+
+const typeDefs = ...
+
+let schema = makeExecutableSchema({
+      typeDefs: [constraintDirectiveTypeDefs, typeDefs]
+})
+
+schema = constraintDirectiveDocumentation()(schema);
+
+// any constraint directive handler implementation
+```
+
+This transformation appends `constraint documentation header`, and then list of `constraint conditions descriptions` to description 
+of each field and argument where `@constraint` directive is used. 
+
+Original schema:
+```graphql
+"""
+Existing field or argument description.
+"""
+fieldOrArgument: String @constraint(minLength: 10, maxLength: 50)
+```
+
+Transformed schema:
+```graphql
+"""
+Existing field or argument description.
+
+*Constraints:*
+* Minimal length: `10`
+* Maximal length: `50`
+"""
+fieldOrArgument: String @constraint(minLength: 10, maxLength: 50)
+```
+
+[CommonMark](https://spec.commonmark.org) is used in the desccription for better readability.
+
+If `constraint documentation header` already exists in the field or argument description, then 
+constraint documentation is not appended. This allows you to override constraint description 
+when necessary, or use this in a chain of subgraph/supergraph schemes.
+
+Both `constraint documentation header` and `constraint conditions descriptions` can be customized 
+during the transformation creation, eg. to localize them.
+
+```js
+schema = constraintDirectiveDocumentation(
+  {
+    header: '*Changed header:*',
+    descriptionsMap: {
+      minLength: 'Changed Minimal length',
+      maxLength: 'Changed Maximal length',
+      startsWith: 'Changed Starts with',
+      endsWith: 'Changed Ends with',
+      contains: 'Changed Contains',
+      notContains: 'Changed Doesn\'t contain',
+      pattern: 'Changed Must match RegEx pattern',
+      format: 'Changed Must match format',
+      min: 'Changed Minimal value',
+      max: 'Changed Maximal value',
+      exclusiveMin: 'Changed Grater than',
+      exclusiveMax: 'Changed Less than',
+      multipleOf: 'Changed Must be a multiple of',
+      minItems: 'Changed Minimal number of items',
+      maxItems: 'Changed Maximal number of items'
+    }
+  }
+)(schema);
+```
+
 
 ## API
 ### String

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ There are multiple ways to make use of the constraint directive in your project.
 
 ### Schema wrapper
 
-Implementation based on schema wrappers - basic scalars are wrapped as custom scalars with validations. 
+Implementation based on schema wrappers - basic scalars are wrapped as custom scalars with validations.
 
 #### Benefits
-* based on `graphql` library, works everywhere 
+* based on `graphql` library, works everywhere
 * posibility to also validate GraphQL response data
 
 #### Caveats
@@ -153,7 +153,7 @@ const plugins = [
 ]
 
 const app = express()
-const server = new ApolloServer({ 
+const server = new ApolloServer({
   schema,
   plugins
 })
@@ -200,7 +200,7 @@ const plugins = [
 ]
 
 const app = express()
-const server = new ApolloServer({ 
+const server = new ApolloServer({
   schema,
   plugins
 })
@@ -262,9 +262,9 @@ await startStandaloneServer(server);
 
 #### Express
 
-*This implementation is untested now, as [`express-graphql` module](https://github.com/graphql/express-graphql) is not maintained anymore.* 
+*This implementation is untested now, as [`express-graphql` module](https://github.com/graphql/express-graphql) is not maintained anymore.*
 
-As a [Validation rule](https://graphql.org/graphql-js/validation/) when query `variables` are available 
+As a [Validation rule](https://graphql.org/graphql-js/validation/) when query `variables` are available
 
 ```js
 const { createQueryValidationRule, constraintDirectiveTypeDefs } = require('graphql-constraint-directive')
@@ -308,8 +308,7 @@ app.listen(4000);
 ```
 ### Schema documentation
 
-You can use provided schema transformation to automatically add `@constraint` documentation into fields and arguments descriptions,
-so clients/users know them, as directive itself is typically not present in the exposed schema.
+You can use the provided schema transformation to automatically add `@constraint` documentation into fields and arguments descriptions. By default directives are not typically present in the exposed introspected schema
 
 ```js
 const { constraintDirectiveTypeDefs, constraintDirectiveDocumentation } = require('graphql-constraint-directive')
@@ -326,8 +325,7 @@ schema = constraintDirectiveDocumentation()(schema);
 // any constraint directive handler implementation
 ```
 
-This transformation appends `constraint documentation header`, and then list of `constraint conditions descriptions` to description 
-of each field and argument where `@constraint` directive is used. 
+This transformation appends `constraint documentation header`, and then a list of `constraint conditions descriptions` to the description of each field and argument where the `@constraint` directive is used.
 
 Original schema:
 ```graphql
@@ -343,19 +341,19 @@ Transformed schema:
 Existing field or argument description.
 
 *Constraints:*
-* Minimal length: `10`
-* Maximal length: `50`
+* Minimum length: `10`
+* Maximum length: `50`
 """
 fieldOrArgument: String @constraint(minLength: 10, maxLength: 50)
 ```
 
 [CommonMark](https://spec.commonmark.org) is used in the desccription for better readability.
 
-If `constraint documentation header` already exists in the field or argument description, then 
-constraint documentation is not appended. This allows you to override constraint description 
+If `constraint documentation header` already exists in the field or argument description, then
+constraint documentation is not appended. This allows you to override constraint description
 when necessary, or use this in a chain of subgraph/supergraph schemes.
 
-Both `constraint documentation header` and `constraint conditions descriptions` can be customized 
+Both `constraint documentation header` and `constraint conditions descriptions` can be customized
 during the transformation creation, eg. to localize them.
 
 ```js
@@ -363,21 +361,21 @@ schema = constraintDirectiveDocumentation(
   {
     header: '*Changed header:*',
     descriptionsMap: {
-      minLength: 'Changed Minimal length',
-      maxLength: 'Changed Maximal length',
+      minLength: 'Changed Minimum length',
+      maxLength: 'Changed Maximum length',
       startsWith: 'Changed Starts with',
       endsWith: 'Changed Ends with',
       contains: 'Changed Contains',
       notContains: 'Changed Doesn\'t contain',
       pattern: 'Changed Must match RegEx pattern',
       format: 'Changed Must match format',
-      min: 'Changed Minimal value',
-      max: 'Changed Maximal value',
+      min: 'Changed Minimum value',
+      max: 'Changed Maximum value',
       exclusiveMin: 'Changed Grater than',
       exclusiveMax: 'Changed Less than',
       multipleOf: 'Changed Must be a multiple of',
-      minItems: 'Changed Minimal number of items',
-      maxItems: 'Changed Maximal number of items'
+      minItems: 'Changed Minimum number of items',
+      maxItems: 'Changed Maximum number of items'
     }
   }
 )(schema);
@@ -488,8 +486,8 @@ app.use('/graphql', bodyParser.json(), graphqlExpress({ schema, formatError }))
 Throws a [`UserInputError`](https://www.apollographql.com/docs/apollo-server/data/errors/#bad_user_input) for each validation error.
 
 #### Apollo Server 4
-Throws a prefilled `GraphQLError` with `extensions.code` set to `BAD_USER_INPUT` and http status code `400`. 
-In case of more validation errors, top level error is generic with `Query is invalid, for details see extensions.validationErrors` message, 
+Throws a prefilled `GraphQLError` with `extensions.code` set to `BAD_USER_INPUT` and http status code `400`.
+In case of more validation errors, top level error is generic with `Query is invalid, for details see extensions.validationErrors` message,
 detailed errors are stored in `extensions.validationErrors` of this error.
 
 #### Envelop
@@ -497,5 +495,5 @@ The Envelop plugin throws a prefilled `GraphQLError` for each validation error.
 
 ### uniqueTypeName
 ```@constraint(uniqueTypeName: "Unique_Type_Name")```
-Override the unique type name generate by the library to the one passed as an argument. 
+Override the unique type name generate by the library to the one passed as an argument.
 Has meaning only for `Schema wrapper` implementation.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,14 +2,68 @@ import {GraphQLSchema, GraphQLError, DocumentNode, ValidationContext} from "grap
 import {PluginDefinition} from "apollo-server-core";
 import QueryValidationVisitor from "./lib/query-validation-visitor";
 
+/**
+ * Schema transformer which adds custom types performing validations based on the @constraint directives.
+ */
 export function constraintDirective () : (schema: GraphQLSchema) => GraphQLSchema;
 
+interface DocumentationOptions {
+    /** Header for the constraints documentation block in the field or argument description */
+    header?: string;
+    /** Names for distinct constraint types */
+    descriptionsMap?: {
+        minLength: string,
+        maxLength: string,
+        startsWith: string,
+        endsWith: string,
+        contains: string,
+        notContains: string,
+        pattern: string,
+        format: string,
+        min: string,
+        max: string,
+        exclusiveMin: string,
+        exclusiveMax: string,
+        multipleOf: string,
+        minItems: string,
+        maxItems: string
+    };
+}
+
+/**
+ * Schema transformer which adds @constraint directives documentation to the fields and arguments descriptions.
+ * Documentation not added if it already exists (`header` is present in the field or argument description)
+ * 
+ * @param options options to customize the documentation process
+ */
+export function constraintDirectiveDocumentation (options: DocumentationOptions) : (schema: GraphQLSchema) => GraphQLSchema;
+
+/**
+ * Type definition for @constraint directive.
+ */
 export const constraintDirectiveTypeDefs: string
 
+/**
+ * Method for query validation based on the @constraint directives defined in the schema.
+ * 
+ * @param schema GraphQL schema to look for directives
+ * @param query GraphQL query to validate
+ * @param variables used in the query to validate
+ * @param operationName optional name of the GraphQL operation to validate
+ */
 export function validateQuery () : (schema: GraphQLSchema, query: DocumentNode, variables: Record<string, any>, operationName?: string) => Array<GraphQLError>;
 
+/**
+ * Create Apollo 3 plugin performing query validation.
+ */
 export function createApolloQueryValidationPlugin ( options: { schema: GraphQLSchema } ) : PluginDefinition;
 
+/**
+ * Create JS GraphQL Validation Rule performing query validation.
+ */
 export function createQueryValidationRule( options: { [key: string]: any }) : (context: ValidationContext) => QueryValidationVisitor;
 
+/**
+ * Create Envelop plugin performing query validation.
+ */
 export function createEnvelopQueryValidationPlugin() : object;

--- a/index.js
+++ b/index.js
@@ -95,6 +95,77 @@ function constraintDirective () {
     })
 }
 
+function constraintDirectiveDocumentation (options) {
+  // Default descriptions, can be changed through options
+  let DESCRIPTINS_MAP = {
+    minLength: 'Minimal length',
+    maxLength: 'Maximal length',
+    startsWith: 'Starts with',
+    endsWith: 'Ends with',
+    contains: 'Contains',
+    notContains: 'Doesn\'t contain',
+    pattern: 'Must match RegEx pattern',
+    format: 'Must match format',
+    min: 'Minimal value',
+    max: 'Maximal value',
+    exclusiveMin: 'Grater than',
+    exclusiveMax: 'Less than',
+    multipleOf: 'Must be a multiple of',
+    minItems: 'Minimal number of items',
+    maxItems: 'Maximal number of items'
+  }
+
+  if (options?.descriptionsMap) {
+    DESCRIPTINS_MAP = options.descriptionsMap
+  }
+
+  let HEADER = '*Constraints:*'
+  if (options?.header) {
+    HEADER = options.header
+  }
+
+  function documentConstraintDirective (fieldConfig, directiveArgumentMap) {
+    if (fieldConfig.description) {
+      // skip documentation if it is already here
+      if (fieldConfig.description.includes(HEADER)) return
+
+      // add two new lines to separate from previous description by paragraph
+      fieldConfig.description += '\n\n'
+    } else {
+      fieldConfig.description = ''
+    }
+
+    fieldConfig.description += HEADER + '\n'
+
+    Object.entries(directiveArgumentMap).forEach(([key, value]) => {
+      if (key === 'uniqueTypeName') return
+      fieldConfig.description += `* ${DESCRIPTINS_MAP[key] ? DESCRIPTINS_MAP[key] : key}: \`${value}\`\n`
+    })
+  }
+
+  return (schema) =>
+    mapSchema(schema, {
+      [MapperKind.FIELD]: (fieldConfig) => {
+        const directiveArgumentMap = getDirective(schema, fieldConfig, 'constraint')?.[0]
+
+        if (directiveArgumentMap) {
+          documentConstraintDirective(fieldConfig, directiveArgumentMap)
+
+          return fieldConfig
+        }
+      },
+      [MapperKind.ARGUMENT]: (fieldConfig) => {
+        const directiveArgumentMap = getDirective(schema, fieldConfig, 'constraint')?.[0]
+
+        if (directiveArgumentMap) {
+          documentConstraintDirective(fieldConfig, directiveArgumentMap)
+
+          return fieldConfig
+        }
+      }
+    })
+}
+
 function validateQuery (schema, query, variables, operationName) {
   const typeInfo = new TypeInfo(schema)
 
@@ -159,4 +230,4 @@ function createQueryValidationRule (options) {
   }
 }
 
-module.exports = { constraintDirective, constraintDirectiveTypeDefs, validateQuery, createApolloQueryValidationPlugin, createEnvelopQueryValidationPlugin, createQueryValidationRule }
+module.exports = { constraintDirective, constraintDirectiveDocumentation, constraintDirectiveTypeDefs, validateQuery, createApolloQueryValidationPlugin, createEnvelopQueryValidationPlugin, createQueryValidationRule }

--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ const {
   visit,
   visitWithTypeInfo,
   separateOperations,
-  GraphQLError
+  GraphQLError,
+  getDirectiveValues
 } = require('graphql')
 const QueryValidationVisitor = require('./lib/query-validation-visitor.js')
 const { getDirective, mapSchema, MapperKind } = require('@graphql-tools/utils')
 const { getConstraintTypeObject, getScalarType } = require('./lib/type-utils')
-const { constraintDirectiveTypeDefs } = require('./lib/type-defs')
+const { constraintDirectiveTypeDefs, constraintDirectiveTypeDefsObj } = require('./lib/type-defs')
 
 function constraintDirective () {
   const constraintTypes = {}
@@ -146,7 +147,7 @@ function constraintDirectiveDocumentation (options) {
   return (schema) =>
     mapSchema(schema, {
       [MapperKind.FIELD]: (fieldConfig) => {
-        const directiveArgumentMap = getDirective(schema, fieldConfig, 'constraint')?.[0]
+        const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, fieldConfig.astNode)
 
         if (directiveArgumentMap) {
           documentConstraintDirective(fieldConfig, directiveArgumentMap)
@@ -155,7 +156,7 @@ function constraintDirectiveDocumentation (options) {
         }
       },
       [MapperKind.ARGUMENT]: (fieldConfig) => {
-        const directiveArgumentMap = getDirective(schema, fieldConfig, 'constraint')?.[0]
+        const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, fieldConfig.astNode)
 
         if (directiveArgumentMap) {
           documentConstraintDirective(fieldConfig, directiveArgumentMap)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "standard && nyc --reporter=html --reporter=text --reporter=lcov mocha test/**/testsuite-full.js",
+    "test-documentation": "standard && nyc --reporter=html --reporter=text --reporter=lcov mocha test/**/testsuite-documentation.js",
     "test-schema-wrapper": "standard && nyc --reporter=html --reporter=text --reporter=lcov mocha test/**/testsuite-schema-wrapper.js",
     "test-apollo-plugin": "standard && nyc --reporter=html --reporter=text --reporter=lcov mocha test/**/testsuite-apollo-plugin.js",
     "test-apollo4-plugin": "standard && nyc --reporter=html --reporter=text --reporter=lcov mocha test/**/testsuite-apollo4-plugin.js",

--- a/test/snapshots/ws-1.txt
+++ b/test/snapshots/ws-1.txt
@@ -1,0 +1,50 @@
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+type Query {
+  """Query books field documented"""
+  books(
+    "*Constraints:*\n* Minimal value: `1`\n* Maximal value: `3`\n"
+    size: Int
+
+    " Query argument documented \n\n*Constraints:*\n* Minimal length: `1`\n"
+    first: String
+  ): [Book]
+
+  """ Query book field documented """
+  book: Book
+}
+
+type Book {
+  "*Constraints:*\n* Maximal length: `10`\n"
+  title: String
+
+  "Book description already documented\n\n*Constraints:*\n* Minimal length: `10`\n* Maximal length: `50`\n"
+  description: String
+  authors(
+    "Book authors argument documented\n\n*Constraints:*\n* Maximal value: `4`\n"
+    size: Int
+
+    """
+    Already documented
+    
+    *Constraints:*
+    * Minimal length as documented: 1
+    """
+    first: String
+  ): [String]
+}
+
+type Mutation {
+  createBook(input: BookInput): Book
+}
+
+input BookInput {
+  "*Constraints:*\n* Minimal value: `3`\n"
+  title: Int!
+  author: AuthorInput
+}
+
+input AuthorInput {
+  "*Constraints:*\n* Minimal length: `2`\n"
+  name: String!
+}

--- a/test/snapshots/ws-2-2.txt
+++ b/test/snapshots/ws-2-2.txt
@@ -1,0 +1,45 @@
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+type Query {
+  """Query books field documented"""
+  books(
+    "My header:\n* Minimal value: `1`\n* Maximal value: `3`\n"
+    size: Int
+
+    " Query argument documented \n\nMy header:\n* Minimal length: `1`\n"
+    first: String
+  ): [Book]
+
+  """ Query book field documented """
+  book: Book
+}
+
+type Book {
+  "My header:\n* Maximal length: `10`\n"
+  title: String
+
+  "Book description already documented\n\nMy header:\n* Minimal length: `10`\n* Maximal length: `50`\n"
+  description: String
+  authors(
+    "Book authors argument documented\n\nMy header:\n* Maximal value: `4`\n"
+    size: Int
+
+    "Already documented\n\n*Constraints:*\n* Minimal length as documented: 1\n\nMy header:\n* Minimal length: `1`\n"
+    first: String
+  ): [String]
+}
+
+type Mutation {
+  createBook(input: BookInput): Book
+}
+
+input BookInput {
+  "My header:\n* Minimal value: `3`\n"
+  title: Int!
+  author: AuthorInput
+}
+
+input AuthorInput {
+  "My header:\n* Minimal length: `2`\n"
+  name: String!
+}

--- a/test/snapshots/ws-2.txt
+++ b/test/snapshots/ws-2.txt
@@ -1,0 +1,45 @@
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+type Query {
+  """Query books field documented"""
+  books(
+    "My header:\n* A Minimal value: `1`\n* A Maximal value: `3`\n"
+    size: Int
+
+    " Query argument documented \n\nMy header:\n* A Minimal length: `1`\n"
+    first: String
+  ): [Book]
+
+  """ Query book field documented """
+  book: Book
+}
+
+type Book {
+  "My header:\n* A Maximal length: `10`\n"
+  title: String
+
+  "Book description already documented\n\nMy header:\n* A Minimal length: `10`\n* A Maximal length: `50`\n"
+  description: String
+  authors(
+    "Book authors argument documented\n\nMy header:\n* A Maximal value: `4`\n"
+    size: Int
+
+    "Already documented\n\n*Constraints:*\n* Minimal length as documented: 1\n\nMy header:\n* A Minimal length: `1`\n"
+    first: String
+  ): [String]
+}
+
+type Mutation {
+  createBook(input: BookInput): Book
+}
+
+input BookInput {
+  "My header:\n* A Minimal value: `3`\n"
+  title: Int!
+  author: AuthorInput
+}
+
+input AuthorInput {
+  "My header:\n* A Minimal length: `2`\n"
+  name: String!
+}

--- a/test/snapshots/ws-3.txt
+++ b/test/snapshots/ws-3.txt
@@ -1,0 +1,64 @@
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+type Query {
+  """Query books field documented"""
+  books(
+    "*Constraints:*\n* Minimal value: `1`\n* Maximal value: `3`\n"
+    size: size_Int_min_1_max_3
+
+    " Query argument documented \n\n*Constraints:*\n* Minimal length: `1`\n"
+    first: first_String_minLength_1
+  ): [Book]
+
+  """ Query book field documented """
+  book: Book
+}
+
+scalar size_Int_min_1_max_3
+
+scalar first_String_minLength_1
+
+type Book {
+  "*Constraints:*\n* Maximal length: `10`\n"
+  title: title_String_maxLength_10
+
+  "Book description already documented\n\n*Constraints:*\n* Minimal length: `10`\n* Maximal length: `50`\n"
+  description: MyString
+  authors(
+    "Book authors argument documented\n\n*Constraints:*\n* Maximal value: `4`\n"
+    size: size_Int_max_4
+
+    """
+    Already documented
+    
+    *Constraints:*
+    * Minimal length as documented: 1
+    """
+    first: first_String_minLength_1
+  ): [String]
+}
+
+scalar title_String_maxLength_10
+
+scalar MyString
+
+scalar size_Int_max_4
+
+type Mutation {
+  createBook(input: BookInput): Book
+}
+
+input BookInput {
+  "*Constraints:*\n* Minimal value: `3`\n"
+  title: title_Int_NotNull_min_3!
+  author: AuthorInput
+}
+
+scalar title_Int_NotNull_min_3
+
+input AuthorInput {
+  "*Constraints:*\n* Minimal length: `2`\n"
+  name: name_String_NotNull_minLength_2!
+}
+
+scalar name_String_NotNull_minLength_2

--- a/test/testsuite-documentation.js
+++ b/test/testsuite-documentation.js
@@ -1,0 +1,136 @@
+const { constraintDirectiveTypeDefs, constraintDirectiveDocumentation, constraintDirective } = require('..')
+const { makeExecutableSchema } = require('@graphql-tools/schema')
+const { printSchema } = require('graphql')
+const { equal } = require('assert')
+const fs = require('fs')
+
+/**
+ * If `true` schema data are refreshed in the storage, if `false` schema is compared with the data in the storage
+ */
+const REFRESH_SCHEMA_DATA = false
+
+if (REFRESH_SCHEMA_DATA) { console.log('WARNING: Schema data are refreshed in the storage, no assertion occurs') }
+
+function assertSchemaData (name, schema) {
+  const fn = './test/snapshots/' + name + '.txt'
+  const sd = printSchema(schema)
+  if (REFRESH_SCHEMA_DATA) {
+    fs.writeFileSync(fn, sd)
+  } else {
+    equal(sd, '' + fs.readFileSync(fn))
+  }
+}
+
+describe('Schema Documentation', function () {
+  const typeDefs = /* GraphQL */`
+
+  type Query {
+    """Query books field documented"""
+    books (
+      size: Int @constraint(max: 3, min: 1), 
+      """ Query argument documented """
+      first: String @constraint(minLength: 1) 
+    ): [Book]
+    """ Query book field documented """
+    book: Book
+  }
+  type Book {
+    title: String @constraint(maxLength: 10)
+    """
+    Book description already documented
+
+    """
+    description: String @constraint(
+      minLength: 10, 
+      maxLength: 50,
+      uniqueTypeName: "MyString"
+    )
+
+    authors (
+      """ 
+      Book authors argument documented
+      """
+      size: Int @constraint(max: 4),
+      """ 
+      Already documented
+
+      *Constraints:*
+      * Minimal length as documented: 1
+      """
+      first: String @constraint(minLength: 1) 
+    ): [String]
+  }
+  type Mutation {
+    createBook(input: BookInput): Book
+  }
+  input BookInput {
+    title: Int! @constraint(min: 3)
+    author: AuthorInput
+  }
+  input AuthorInput {
+    name: String! @constraint(minLength: 2)
+  }
+  `
+
+  it('works - default options', async function () {
+    let schema = makeExecutableSchema({
+      typeDefs: [constraintDirectiveTypeDefs, typeDefs]
+    })
+
+    schema = constraintDirectiveDocumentation()(schema)
+
+    assertSchemaData('ws-1', schema)
+  })
+
+  it('works - customized options', async function () {
+    let schema = makeExecutableSchema({
+      typeDefs: [constraintDirectiveTypeDefs, typeDefs]
+    })
+
+    schema = constraintDirectiveDocumentation({
+      header: 'My header:',
+      descriptionsMap: {
+        minLength: 'A Minimal length',
+        maxLength: 'A Maximal length',
+        startsWith: 'A Starts with',
+        endsWith: 'A Ends with',
+        contains: 'A Contains',
+        notContains: 'A Doesn\'t contain',
+        pattern: 'A Must match RegEx pattern',
+        format: 'A Must match format',
+        min: 'A Minimal value',
+        max: 'A Maximal value',
+        exclusiveMin: 'A Grater than',
+        exclusiveMax: 'A Less than',
+        multipleOf: 'A Must be a multiple of',
+        minItems: 'A Minimal number of items',
+        maxItems: 'A Maximal number of items'
+      }
+    })(schema)
+
+    assertSchemaData('ws-2', schema)
+  })
+
+  it('works - customized header', async function () {
+    let schema = makeExecutableSchema({
+      typeDefs: [constraintDirectiveTypeDefs, typeDefs]
+    })
+
+    schema = constraintDirectiveDocumentation({
+      header: 'My header:'
+    })(schema)
+
+    assertSchemaData('ws-2-2', schema)
+  })
+
+  it('works after wrapper impl transformation', async function () {
+    let schema = makeExecutableSchema({
+      typeDefs: [constraintDirectiveTypeDefs, typeDefs]
+    })
+
+    schema = constraintDirective()(schema)
+    schema = constraintDirectiveDocumentation()(schema)
+
+    assertSchemaData('ws-3', schema)
+  })
+})

--- a/test/testsuite-full.js
+++ b/test/testsuite-full.js
@@ -3,3 +3,4 @@ require('./testsuite-apollo-plugin')
 require('./testsuite-apollo4-plugin')
 require('./testsuite-envelop-plugin')
 // require('./testsuite-validation-rule-express-graphql') // deprecated, may be removed later or rewritent to another server if available
+require('./testsuite-documentation')


### PR DESCRIPTION
As requested in #4 created schema transformer which adds documentation to fields and arguments where `@constraint` directive is used.

[CommonMark](https://spec.commonmark.org) markdown is used in default documentation texts as it is allowed by the GraphQL specification

Constraint description consist of header and list with items for each validated condition. 

If field/argument description exists already, the constraint description is appended to it as new paragraph.

Documentation of the constraints is not added if it already exists (checked over presence of the header)

Both header and condition descriptions can be customized during the transformer creation.

Everything is tested.
