### PR TITLE
Fix #172 declaration of QueryValidationVisitor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
 import {GraphQLSchema, GraphQLError, DocumentNode, ValidationContext} from "graphql";
-import {OperationDefinitionNode, FragmentDefinitionNode, InlineFragmentNode, FieldNode} from 'graphql/language';
+import {OperationDefinitionNode, FragmentDefinitionNode, InlineFragmentNode, FieldNode, ArgumentNode} from 'graphql/language';
 import {PluginDefinition} from "apollo-server-core";
 
 export class QueryValidationVisitor {
-    onOperationDefinitionEnter (operation: OperationDefinitionNode);
-    onFragmentEnter (node: FragmentDefinitionNode | InlineFragmentNode);
-    onFragmentLeave (node: FragmentDefinitionNode | InlineFragmentNode);
-    onFieldEnter (node: FieldNode);
-    onFieldLeave (node: FieldNode);
-    onArgumentEnter (arg: ArgumentNode);
+    onOperationDefinitionEnter (operation: OperationDefinitionNode): void;
+    onFragmentEnter (node: FragmentDefinitionNode | InlineFragmentNode): void;
+    onFragmentLeave (node: FragmentDefinitionNode | InlineFragmentNode): void;
+    onFieldEnter (node: FieldNode): void;
+    onFieldLeave (node: FieldNode): void;
+    onArgumentEnter (arg: ArgumentNode): void;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,15 @@
 import {GraphQLSchema, GraphQLError, DocumentNode, ValidationContext} from "graphql";
+import {OperationDefinitionNode, FragmentDefinitionNode, InlineFragmentNode, FieldNode} from 'graphql/language';
 import {PluginDefinition} from "apollo-server-core";
-import QueryValidationVisitor from "./lib/query-validation-visitor";
+
+export class QueryValidationVisitor {
+    onOperationDefinitionEnter (operation: OperationDefinitionNode);
+    onFragmentEnter (node: FragmentDefinitionNode | InlineFragmentNode);
+    onFragmentLeave (node: FragmentDefinitionNode | InlineFragmentNode);
+    onFieldEnter (node: FieldNode);
+    onFieldLeave (node: FieldNode);
+    onArgumentEnter (arg: ArgumentNode);
+}
 
 /**
  * Schema transformer which adds custom types performing validations based on the @constraint directives.


### PR DESCRIPTION
Seems like explicitly defining the class signatures fixes compilation errors with `tsc`

Let me know if you don't agree with this approach!