### PR TITLE
Add support for passing custom formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,32 @@ Supported formats:
 - uri
 - uuid
 
+#### Custom Format
+You can add your own custom formats by passing a `formats` object to the plugin options. See example below.
+
+```@constraint(format: "my-custom-format")```
+
+```js
+const formats = {
+  'my-custom-format': (value) => {
+    if (value === 'foo') {
+      return true
+    }
+
+    throw new GraphQLError('Value must be foo')
+  }
+};
+
+// Envelop
+createEnvelopQueryValidationPlugin({ formats })
+
+// Apollo 3 Server
+createApolloQueryValidationPlugin({ formats })
+
+// Apollo 4 Server
+createApollo4QueryValidationPlugin({ formats })
+```
+
 ### Int/Float
 #### min
 ```@constraint(min: 3)```

--- a/apollo4.js
+++ b/apollo4.js
@@ -9,7 +9,7 @@ const { gql } = require('graphql-tag')
 
 let currentSchema
 
-function createApollo4QueryValidationPlugin () {
+function createApollo4QueryValidationPlugin (options = {}) {
   return {
     async serverWillStart () {
       return {
@@ -30,7 +30,8 @@ function createApollo4QueryValidationPlugin () {
             currentSchema,
             query,
             request.variables,
-            request.operationName
+            request.operationName,
+            options
           )
 
           if (errors.length > 0) {

--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -135,7 +135,7 @@ module.exports = class QueryValidationVisitor {
 
       const inputObjectTypeDef = getNamedType(valueTypeDef)
 
-      validateInputTypeValue(this.context, inputObjectTypeDef, argName, variableName, value, this.currentField, variableName)
+      validateInputTypeValue(this.context, inputObjectTypeDef, argName, variableName, value, this.currentField, variableName, this.options)
     } else if (isListType(valueTypeDef)) {
       validateArrayTypeValue(this.context, valueTypeDef, argTypeDef, value, this.currentField, argName, variableName, variableName)
     } else {
@@ -144,12 +144,12 @@ module.exports = class QueryValidationVisitor {
 
       const fieldNameForError = variableName || this.currentField.name.value + '.' + argName
 
-      validateScalarTypeValue(this.context, this.currentField, argTypeDef, valueTypeDef, value, variableName, argName, fieldNameForError, '')
+      validateScalarTypeValue(this.context, this.currentField, argTypeDef, valueTypeDef, value, variableName, argName, fieldNameForError, '', this.options)
     }
   }
 }
 
-function validateScalarTypeValue (context, currentQueryField, typeDefWithDirective, valueTypeDef, value, variableName, argName, fieldNameForError, errMessageAt) {
+function validateScalarTypeValue (context, currentQueryField, typeDefWithDirective, valueTypeDef, value, variableName, argName, fieldNameForError, errMessageAt, options = {}) {
   if (!typeDefWithDirective.astNode) { return }
 
   const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, typeDefWithDirective.astNode)
@@ -159,7 +159,7 @@ function validateScalarTypeValue (context, currentQueryField, typeDefWithDirecti
     const valueDelim = st === GraphQLString ? '"' : ''
 
     try {
-      getConstraintValidateFn(st)(fieldNameForError, directiveArgumentMap, value)
+      getConstraintValidateFn(st)(fieldNameForError, directiveArgumentMap, value, options)
     } catch (e) {
       let error
 
@@ -175,11 +175,11 @@ function validateScalarTypeValue (context, currentQueryField, typeDefWithDirecti
   }
 }
 
-function validateInputTypeValue (context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames) {
+function validateInputTypeValue (context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames, options = {}) {
   if (!inputObjectTypeDef.astNode) { return }
 
   // use new visitor to traverse input object structure
-  const visitor = new InputObjectValidationVisitor(context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames)
+  const visitor = new InputObjectValidationVisitor(context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames, options)
 
   visit(inputObjectTypeDef.astNode, visitor)
 }
@@ -230,18 +230,18 @@ function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, va
       const iFieldNameFullIndexed = iFieldNameFull ? `${iFieldNameFull}[${index++}]` : `[${index++}]`
 
       if (isInputObjectType(valueTypeDefArray)) {
-        validateInputTypeValue(context, valueTypeDefArray, argName, variableName, element, currentField, iFieldNameFullIndexed)
+        validateInputTypeValue(context, valueTypeDefArray, argName, variableName, element, currentField, iFieldNameFullIndexed, this.options)
       } else if (hasNonListValidation) {
         const atMessage = ` at "${iFieldNameFullIndexed}"`
 
-        validateScalarTypeValue(context, currentField, typeDefWithDirective, valueTypeDef, element, variableName, argName, iFieldNameFullIndexed, atMessage)
+        validateScalarTypeValue(context, currentField, typeDefWithDirective, valueTypeDef, element, variableName, argName, iFieldNameFullIndexed, atMessage, this.options)
       }
     })
   }
 }
 
 class InputObjectValidationVisitor {
-  constructor (context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames) {
+  constructor (context, inputObjectTypeDef, argName, variableName, value, currentField, parentNames, options = {}) {
     this.context = context
     this.argName = argName
     this.variableName = variableName
@@ -250,6 +250,7 @@ class InputObjectValidationVisitor {
     this.value = value
     this.currentField = currentField
     this.parentNames = parentNames
+    this.options = options
 
     this.InputValueDefinition = {
       enter: this.onInputValueDefinition
@@ -273,14 +274,14 @@ class InputObjectValidationVisitor {
       // nothing to validate
       if (!value) return
 
-      validateInputTypeValue(this.context, valueTypeDef, this.argName, this.variableName, value, this.currentField, iFieldNameFull)
+      validateInputTypeValue(this.context, valueTypeDef, this.argName, this.variableName, value, this.currentField, iFieldNameFull, this.options)
     } else if (isListType(valueTypeDef)) {
       validateArrayTypeValue(this.context, valueTypeDef, iFieldTypeDef, value, this.currentField, this.argName, this.variableName, iFieldNameFull)
     } else {
       // nothing to validate
       if (!value && value !== '' && value !== 0) return
 
-      validateScalarTypeValue(this.context, this.currentField, iFieldTypeDef, valueTypeDef, value, this.variableName, this.argName, iFieldNameFull, ` at "${iFieldNameFull}"`)
+      validateScalarTypeValue(this.context, this.currentField, iFieldTypeDef, valueTypeDef, value, this.variableName, this.argName, iFieldNameFull, ` at "${iFieldNameFull}"`, this.options)
     }
   }
 }

--- a/test/setup-apollo-plugin.js
+++ b/test/setup-apollo-plugin.js
@@ -4,7 +4,7 @@ const { makeExecutableSchema } = require('@graphql-tools/schema')
 const request = require('supertest')
 const { createApolloQueryValidationPlugin, constraintDirectiveTypeDefs } = require('..')
 
-module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback, pluginOptions = {} }) {
   let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
@@ -15,9 +15,7 @@ module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreat
   }
 
   const plugins = [
-    createApolloQueryValidationPlugin({
-      schema
-    })
+    createApolloQueryValidationPlugin({ schema }, pluginOptions)
   ]
 
   const app = express()

--- a/test/setup-apollo4-plugin.js
+++ b/test/setup-apollo4-plugin.js
@@ -7,7 +7,7 @@ const { json } = require('body-parser')
 const request = require('supertest')
 const { createApollo4QueryValidationPlugin, constraintDirectiveTypeDefs } = require('../apollo4')
 
-module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback, pluginOptions = {} }) {
   let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
@@ -18,7 +18,7 @@ module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreat
   }
 
   const plugins = [
-    createApollo4QueryValidationPlugin()
+    createApollo4QueryValidationPlugin(pluginOptions)
   ]
 
   const app = express()

--- a/test/setup-envelop-plugin.js
+++ b/test/setup-envelop-plugin.js
@@ -4,7 +4,7 @@ const { createServer } = require('@graphql-yoga/node')
 const request = require('supertest')
 const { createEnvelopQueryValidationPlugin, constraintDirectiveTypeDefs } = require('..')
 
-module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback, pluginOptions = {} }) {
   let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
@@ -17,7 +17,7 @@ module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreat
   const app = express()
   const yoga = createServer({
     schema,
-    plugins: [createEnvelopQueryValidationPlugin()],
+    plugins: [createEnvelopQueryValidationPlugin(pluginOptions)],
     graphiql: false
   })
 

--- a/test/setup-schema-wrapper.js
+++ b/test/setup-schema-wrapper.js
@@ -4,7 +4,7 @@ const { makeExecutableSchema } = require('@graphql-tools/schema')
 const request = require('supertest')
 const { constraintDirectiveTypeDefs, constraintDirective } = require('..')
 
-module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback, pluginOptions = {} }) {
   let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers

--- a/test/setup-validation-rule-express-graphql.js
+++ b/test/setup-validation-rule-express-graphql.js
@@ -4,7 +4,7 @@ const { makeExecutableSchema } = require('@graphql-tools/schema')
 const request = require('supertest')
 const { createQueryValidationRule, constraintDirectiveTypeDefs } = require('..')
 
-module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback }) {
+module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreatedCallback, pluginOptions = {} }) {
   let schema = makeExecutableSchema({
     typeDefs: [constraintDirectiveTypeDefs, typeDefs],
     resolvers
@@ -22,7 +22,8 @@ module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreat
       schema,
       validationRules: [
         createQueryValidationRule({
-          variables
+          variables,
+          pluginOptions
         })
       ]
     }))


### PR DESCRIPTION
I've added a feature that allows the use of custom formats. The README.md has also been updated which shows how it works and how to use it through the JS API.