### PR TITLE
Fix falsy string and int query values

### DIFF
--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -140,7 +140,7 @@ module.exports = class QueryValidationVisitor {
       validateArrayTypeValue(this.context, valueTypeDef, argTypeDef, value, this.currentField, argName, variableName, variableName)
     } else {
       // nothing to validate
-      if (!value) return
+      if (!value && value !== '' && value !== 0) return
 
       const fieldNameForError = variableName || this.currentField.name.value + '.' + argName
 

--- a/test/variable.test.js
+++ b/test/variable.test.js
@@ -2,7 +2,9 @@ const { deepStrictEqual, strictEqual } = require('assert')
 const { valueByImplType, isStatusCodeError } = require('./testutils')
 
 module.exports.test = function (setup, implType) {
-  const queryIntType = valueByImplType(implType, 'size_Int_max_3', 'Int')
+  const queryIntMaxType = valueByImplType(implType, 'size_Int_max_3', 'Int')
+  const queryIntMinType = valueByImplType(implType, 'size_Int_min_3', 'Int')
+  const queryStringMinLengthType = valueByImplType(implType, 'search_String_minLength_3', 'String')
 
   describe('Variables', function () {
     describe('variable default value', function () {
@@ -20,7 +22,7 @@ module.exports.test = function (setup, implType) {
 
       it('should pass', async function () {
         const query = /* GraphQL */`
-          query ($size: ${queryIntType} = 3) {
+          query ($size: ${queryIntMaxType} = 3) {
             books(size: $size) {
                 title
             }
@@ -37,7 +39,7 @@ module.exports.test = function (setup, implType) {
 
       it('should fail', async function () {
         const query = /* GraphQL */`
-          query ($size: ${queryIntType} = 4) {
+          query ($size: ${queryIntMaxType} = 4) {
             books(size: $size) {
                 title
             }
@@ -51,6 +53,104 @@ module.exports.test = function (setup, implType) {
         isStatusCodeError(statusCode, implType)
         strictEqual(body.errors[0].message,
           valueByImplType(implType, 'Expected value of type "size_Int_max_3", found 4;', 'Variable "$size" got invalid value 4.') + ' Must be no greater than 3')
+      })
+    })
+
+    describe('variable int falsy', function () {
+      before(async function () {
+        this.typeDefs = /* GraphQL */`
+          type Query {
+            books (size: Int @constraint(min: 3)): [Book]
+          }
+          type Book {
+            title: String
+          }
+        `
+        this.request = await setup({ typeDefs: this.typeDefs })
+      })
+
+      it('should pass', async function () {
+        const query = /* GraphQL */`
+          query ($size: ${queryIntMinType} = 3) {
+            books(size: $size) {
+              title
+            }
+        }
+        `
+        const { body, statusCode } = await this.request
+          .post('/graphql')
+          .set('Accept', 'application/json')
+          .send({ query })
+
+        strictEqual(statusCode, 200)
+        deepStrictEqual(body, { data: { books: null } })
+      })
+
+      it('should fail', async function () {
+        const query = /* GraphQL */`
+          query ($size: ${queryIntMinType} = 0) {
+            books(size: $size) {
+              title
+            }
+          }
+        `
+        const { body, statusCode } = await this.request
+          .post('/graphql')
+          .set('Accept', 'application/json')
+          .send({ query })
+
+        isStatusCodeError(statusCode, implType)
+        strictEqual(body.errors[0].message,
+          valueByImplType(implType, 'Expected value of type "size_Int_min_3", found 0;', 'Variable "$size" got invalid value 0.') + ' Must be at least 3')
+      })
+    })
+
+    describe('variable string falsy', function () {
+      before(async function () {
+        this.typeDefs = /* GraphQL */`
+          type Query {
+            books (search: String @constraint(minLength: 3)): [Book]
+          }
+          type Book {
+            title: String
+          }
+        `
+        this.request = await setup({ typeDefs: this.typeDefs })
+      })
+
+      it('should pass', async function () {
+        const query = /* GraphQL */`
+          query ($search: ${queryStringMinLengthType} = "test") {
+            books(search: $search) {
+              title
+            }
+          }
+        `
+        const { body, statusCode } = await this.request
+          .post('/graphql')
+          .set('Accept', 'application/json')
+          .send({ query })
+
+        strictEqual(statusCode, 200)
+        deepStrictEqual(body, { data: { books: null } })
+      })
+
+      it('should fail - despite being falsy', async function () {
+        const query = /* GraphQL */`
+          query ($search: ${queryStringMinLengthType} = "") {
+            books(search: $search) {
+              title
+            }
+          }
+        `
+        const { body, statusCode } = await this.request
+          .post('/graphql')
+          .set('Accept', 'application/json')
+          .send({ query })
+
+        isStatusCodeError(statusCode, implType)
+        strictEqual(body.errors[0].message,
+          valueByImplType(implType, 'Expected value of type "search_String_minLength_3", found "";', 'Variable "$search" got invalid value "".') + ' Must be at least 3 characters in length')
       })
     })
   })


### PR DESCRIPTION
#133 and #177 fixed this for input objects, but not query values.

Sending a 0 value on an int with min constraint or an empty string on a string with minLength constraint would skip validation previously.

Making the values non-nullable doesn't help, and using defaults (in a resolver) _can_ help, but not for all cases. For instance for an auth query you don't want to give a username a default and cause db queries for something that should be failing validation.

See #187 for an example of the problem.