### PR TITLE
patched documentation schema transformer to change description in astNode also

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,8 @@ function constraintDirectiveDocumentation (options) {
       if (key === 'uniqueTypeName') return
       fieldConfig.description += `* ${DESCRIPTINS_MAP[key] ? DESCRIPTINS_MAP[key] : key}: \`${value}\`\n`
     })
+
+    if (fieldConfig.astNode?.description) { fieldConfig.astNode.description.value = fieldConfig.description }
   }
 
   return (schema) =>


### PR DESCRIPTION
In our project, we use `printSchemaWithDirectives` method from some library, which prefers `description` from `astNode`. So this change only makes sure that both descriptions are the same.