### PR TITLE
fix: Updated apollo server 4 typescript d files to match javascript

### DIFF
--- a/apollo4.d.ts
+++ b/apollo4.d.ts
@@ -1,4 +1,4 @@
-import {DocumentNode, GraphQLSchema} from "graphql";
+import {DocumentNode} from "graphql";
 import {ApolloServerPlugin} from '@apollo/server';
 
 /**
@@ -14,6 +14,6 @@ export const constraintDirectiveTypeDefsGql: DocumentNode;
 /**
  * Create Apollo 4 validation plugin.
  * 
- * @param options to setup plugin. `schema` is deprecated now, not used, as plugins gets schema from the Apollo Server.
+ * @param options to setup plugin.
  */
-export function createApollo4QueryValidationPlugin ( options: { schema?: GraphQLSchema } ) : ApolloServerPlugin;
+export function createApollo4QueryValidationPlugin ( options?: {} ) : ApolloServerPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export const constraintDirectiveTypeDefs: string
  * @param variables used in the query to validate
  * @param operationName optional name of the GraphQL operation to validate
  */
-export function validateQuery () : (schema: GraphQLSchema, query: DocumentNode, variables: Record<string, any>, operationName?: string) => Array<GraphQLError>;
+export function validateQuery () : (schema: GraphQLSchema, query: DocumentNode, variables: Record<string, any>, operationName?: string, pluginOptions?: {}) => Array<GraphQLError>;
 
 /**
  * Create Apollo 3 plugin performing query validation.

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:koivumi79/graphql-constraint-directive.git"
+    "url": "git@github.com:confuser/graphql-constraint-directive.git"
   },
   "bugs": {
-    "url": "https://github.com/koivumi79/graphql-constraint-directive/issues"
+    "url": "https://github.com/confuser/graphql-constraint-directive/issues"
   },
   "keywords": [
     "graphql",


### PR DESCRIPTION
Custom format validation was not working for apollo server 4 plugin due incorrect options parameter. Fixed the parameter to match javascript files.