### PR TITLE
fix: yoga server not showing envelop extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ function createEnvelopQueryValidationPlugin (options = {}) {
     onExecute ({ args, setResultAndStopExecution }) {
       const errors = validateQuery(args.schema, args.document, args.variableValues, args.operationName, options)
       if (errors.length > 0) {
-        setResultAndStopExecution({ errors: errors.map(err => { return new GraphQLError(err.message, err, { code: err.code, field: err.fieldName, context: err.context, exception: err.originalError }) }) })
+        setResultAndStopExecution({ errors: errors.map(err => { return new GraphQLError(err.message, { extensions: { code: err.code, field: err.fieldName, context: err.context } }) }) })
       }
     }
   }

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -147,6 +147,29 @@ module.exports.test = function (setup, implType) {
           })
         })
       }
+
+      if (isServerValidatorEnvelop(implType)) {
+        it('should throw custom error', async function () {
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
+          const { body } = await request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query, variables: { input: { title: 'fob💩' } } })
+
+          deepStrictEqual(body, {
+            errors: [
+              {
+                message: 'Variable "$input" got invalid value "fob💩" at "input.title". Must be no more than 3 characters in length',
+                extensions: {
+                  code: 'ERR_GRAPHQL_CONSTRAINT_VALIDATION',
+                  field: 'input.title',
+                  context: [{ arg: 'maxLength', value: 3 }]
+                }
+              }
+            ]
+          })
+        })
+      }
     })
 
     describe('#startsWith', function () {


### PR DESCRIPTION
Yoga only will show the code, field, context if they are part of the extensions object.

Before:
![image](https://github.com/confuser/graphql-constraint-directive/assets/6627528/5a0c1ad9-394c-4427-8dea-b23d2b291c98)


After:
![image](https://github.com/confuser/graphql-constraint-directive/assets/6627528/7b623f61-6498-4b58-bc9a-6b21cd4a57e4)
