### PR TITLE
Fix for trying to read args on undefined

### DIFF
--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -115,7 +115,7 @@ module.exports = class QueryValidationVisitor {
   onArgumentEnter (arg) {
     const argName = arg.name.value
     // look for directive and validate argument if directive found
-    const argTypeDef = this.currentrFieldDef.args.find(d => d.name === argName)
+    const argTypeDef = this.currentrFieldDef?.args.find(d => d.name === argName)
 
     if (!argTypeDef) return
 

--- a/test/foreign-query-directives.test.js
+++ b/test/foreign-query-directives.test.js
@@ -30,7 +30,6 @@ module.exports.test = function (setup, implType) {
           }
         }
       `
-      // Assuming this.request is a configured client to make GraphQL requests to your server
       const { body, statusCode } = await this.request
         .post('/graphql')
         .set('Accept', 'application/json')

--- a/test/foreign-query-directives.test.js
+++ b/test/foreign-query-directives.test.js
@@ -1,0 +1,52 @@
+const { deepStrictEqual, strictEqual } = require('assert')
+
+module.exports.test = function (setup, implType) {
+  describe('Directive Argument Handling', function () {
+    before(async function () {
+      this.typeDefs = `
+        directive @component(name: String!) on QUERY | MUTATION | SUBSCRIPTION
+
+        type Query {
+          getUsers: [User]
+        }
+
+        type User {
+          id: ID
+          name: String
+          email: String
+        }
+      `
+
+      this.request = await setup({ typeDefs: this.typeDefs })
+    })
+
+    it("should not throw \"Cannot read properties of undefined (reading 'args')\" error when querying", async function () {
+      const query = `
+        query GetCurrentUser @component(name: "exampleComponent") {
+          getUsers {
+            id
+            name
+            email
+          }
+        }
+      `
+      // Assuming this.request is a configured client to make GraphQL requests to your server
+      const { body, statusCode } = await this.request
+        .post('/graphql')
+        .set('Accept', 'application/json')
+        .send({ query })
+
+      // Check for successful execution and no errors in the response
+      strictEqual(
+        statusCode,
+        200,
+        'Expected HTTP status code 200 for successful GraphQL query execution.'
+      )
+      deepStrictEqual(
+        body.errors,
+        undefined,
+        'Expected no errors in the GraphQL response.'
+      )
+    })
+  })
+}

--- a/test/foreign-query-directives.test.js
+++ b/test/foreign-query-directives.test.js
@@ -7,13 +7,7 @@ module.exports.test = function (setup, implType) {
         directive @component(name: String!) on QUERY | MUTATION | SUBSCRIPTION
 
         type Query {
-          getUsers: [User]
-        }
-
-        type User {
-          id: ID
-          name: String
-          email: String
+          getName: String!
         }
       `
 
@@ -22,12 +16,8 @@ module.exports.test = function (setup, implType) {
 
     it("should not throw \"Cannot read properties of undefined (reading 'args')\" error when querying", async function () {
       const query = `
-        query GetCurrentUser @component(name: "exampleComponent") {
-          getUsers {
-            id
-            name
-            email
-          }
+        query GetName @component(name: "exampleComponent") {
+          getName
         }
       `
       const { body, statusCode } = await this.request

--- a/test/foreign-query-directives.test.js
+++ b/test/foreign-query-directives.test.js
@@ -7,7 +7,11 @@ module.exports.test = function (setup, implType) {
         directive @component(name: String!) on QUERY | MUTATION | SUBSCRIPTION
 
         type Query {
-          getName: String!
+          books: [Book]
+        }
+        
+        type Book {
+          title: String
         }
       `
 
@@ -17,8 +21,8 @@ module.exports.test = function (setup, implType) {
     it("should not throw \"Cannot read properties of undefined (reading 'args')\" error when querying", async function () {
       const query = `
         query GetName @component(name: "exampleComponent") {
-          getName
-        }
+          books
+        }.
       `
       const { body, statusCode } = await this.request
         .post('/graphql')

--- a/test/foreign-query-directives.test.js
+++ b/test/foreign-query-directives.test.js
@@ -9,7 +9,7 @@ module.exports.test = function (setup, implType) {
         type Query {
           books: [Book]
         }
-        
+
         type Book {
           title: String
         }
@@ -20,8 +20,10 @@ module.exports.test = function (setup, implType) {
 
     it("should not throw \"Cannot read properties of undefined (reading 'args')\" error when querying", async function () {
       const query = `
-        query GetName @component(name: "exampleComponent") {
-          books
+        query GetBooks @component(name: "exampleComponent") {
+          books {
+            title
+          }
         }.
       `
       const { body, statusCode } = await this.request

--- a/test/foreign-query-directives.test.js
+++ b/test/foreign-query-directives.test.js
@@ -7,11 +7,13 @@ module.exports.test = function (setup, implType) {
         directive @component(name: String!) on QUERY | MUTATION | SUBSCRIPTION
 
         type Query {
-          books: [Book]
+          getUsers: [User]
         }
 
-        type Book {
-          title: String
+        type User {
+          id: ID
+          name: String
+          email: String
         }
       `
 
@@ -20,11 +22,13 @@ module.exports.test = function (setup, implType) {
 
     it("should not throw \"Cannot read properties of undefined (reading 'args')\" error when querying", async function () {
       const query = `
-        query GetBooks @component(name: "exampleComponent") {
-          books {
-            title
+        query GetCurrentUser @component(name: "exampleComponent") {
+          getUsers {
+            id
+            name
+            email
           }
-        }.
+        }
       `
       const { body, statusCode } = await this.request
         .post('/graphql')

--- a/test/testsuite-apollo-plugin.js
+++ b/test/testsuite-apollo-plugin.js
@@ -18,4 +18,5 @@ describe('Server validator based implementation - Apollo plugin', function () {
   require('./string.test').test(setup, IMPL_TYPE)
   require('./argument-dynamic.test').test(setup, IMPL_TYPE)
   require('./union.test').test(setup, IMPL_TYPE)
+  require('./foreign-query-directives.test').test(setup, IMPL_TYPE)
 })


### PR DESCRIPTION
We ran into an issue when using a unrelated query directive together with graphql-constraint-directive, where the createApolloQueryValidationPlugin would throw an error whenever the client had a query using that directive. 
The error was:
```
{
  "errors": [
    {
      "message": "Cannot read properties of undefined (reading 'args')",
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR"
      }
    }
  ]
}
```

And our directive was:
`directive @component(name: String!) on QUERY | MUTATION | SUBSCRIPTION`

It appears that this fixes it, and I also added tests.