### PR TITLE
added support for custom scalars

### DIFF
--- a/apollo4.d.ts
+++ b/apollo4.d.ts
@@ -1,5 +1,6 @@
 import {DocumentNode} from "graphql";
 import {ApolloServerPlugin} from '@apollo/server';
+import { PluginOptions } from ".";
 
 /**
  * Constraint directive typeDef as a `string`
@@ -16,4 +17,4 @@ export const constraintDirectiveTypeDefsGql: DocumentNode;
  * 
  * @param options to setup plugin.
  */
-export function createApollo4QueryValidationPlugin ( options?: {} ) : ApolloServerPlugin;
+export function createApollo4QueryValidationPlugin ( options?: PluginOptions ) : ApolloServerPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {GraphQLSchema, GraphQLError, DocumentNode, ValidationContext} from "graphql";
+import {GraphQLSchema, GraphQLError, DocumentNode, ValidationContext, GraphQLScalarType} from "graphql";
 import {OperationDefinitionNode, FragmentDefinitionNode, InlineFragmentNode, FieldNode, ArgumentNode} from 'graphql/language';
 import {PluginDefinition} from "apollo-server-core";
 
@@ -40,7 +40,8 @@ interface DocumentationOptions {
 }
 
 interface PluginOptions {
-    formats: Record<string, (value: unknown) => boolean>;
+    formats?: Record<string, (value: unknown) => boolean>;
+    scalarTypeMappings?: Record<string, GraphQLScalarType>;
 }
 
 /**
@@ -64,7 +65,7 @@ export const constraintDirectiveTypeDefs: string
  * @param variables used in the query to validate
  * @param operationName optional name of the GraphQL operation to validate
  */
-export function validateQuery () : (schema: GraphQLSchema, query: DocumentNode, variables: Record<string, any>, operationName?: string, pluginOptions?: {}) => Array<GraphQLError>;
+export function validateQuery(schema: GraphQLSchema, query: DocumentNode, variables: Record<string, any>, operationName?: string, pluginOptions?: {}): Array<GraphQLError>;
 
 /**
  * Create Apollo 3 plugin performing query validation.

--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -155,7 +155,7 @@ function validateScalarTypeValue (context, currentQueryField, typeDefWithDirecti
   const directiveArgumentMap = getDirectiveValues(constraintDirectiveTypeDefsObj, typeDefWithDirective.astNode)
 
   if (directiveArgumentMap) {
-    const st = getScalarType(valueTypeDef).scalarType
+    const st = getScalarType(valueTypeDef, options).scalarType
     const valueDelim = st === GraphQLString ? '"' : ''
 
     try {

--- a/lib/type-utils.js
+++ b/lib/type-utils.js
@@ -40,15 +40,20 @@ function getConstraintValidateFn (type) {
   }
 }
 
-function getScalarType (fieldConfig) {
+function getScalarType (fieldConfig, options) {
   if (isScalarType(fieldConfig)) {
+    const scalarTypeMappings = options?.pluginOptions?.scalarTypeMappings
+    if (scalarTypeMappings != null) {
+      const scalarType = scalarTypeMappings[fieldConfig.name]
+      if (scalarType) return { scalarType: scalarType }
+    }
     return { scalarType: fieldConfig }
   } else if (isListType(fieldConfig)) {
-    return { ...getScalarType(fieldConfig.ofType), list: true }
+    return { ...getScalarType(fieldConfig.ofType, options), list: true }
   } else if (isNonNullType(fieldConfig) && isScalarType(fieldConfig.ofType)) {
     return { scalarType: fieldConfig.ofType, scalarNotNull: true }
   } else if (isNonNullType(fieldConfig)) {
-    return { ...getScalarType(fieldConfig.ofType.ofType), list: true, listNotNull: true }
+    return { ...getScalarType(fieldConfig.ofType.ofType, options), list: true, listNotNull: true }
   } else {
     throw new Error(`Not a valid scalar type: ${fieldConfig.toString()}`)
   }


### PR DESCRIPTION
Support for custom scalar validation.

In order to validate a custom scalar, a scalar type mapping needs to be created for one of the supported base scalar types.

E.g.:
```ts
import { ApolloServer, ApolloServerPlugin } from "@apollo/server";
import { constraintDirectiveTypeDefs, createApollo4QueryValidationPlugin } from "graphql-constraint-directive/apollo4"
import { makeExecutableSchema } from "@graphql-tools/schema";
import { EmailAddressResolver, typeDefs as scalarTypeDefs } from 'graphql-scalars';
import { GraphQLString } from "graphql";


const typeDefs = `
type Query {
  create(
    email: EmailAddress @constraint(maxLength: 40)
  ): Void
}
`

const schema = makeExecutableSchema({
    typeDefs: [constraintDirectiveTypeDefs, ...scalarTypeDefs, typeDefs],
    resolvers,
})

const plugins: ApolloServerPlugin[] = [
    createApollo4QueryValidationPlugin({
        scalarTypeMappings: {
            [NonEmptyStringResolver.name]: GraphQLString
        }
    })
]

const server = new ApolloServer({ 
    schema, 
    plugins,
});

```