### PR TITLE
Allow custom formats on schema wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Supported formats:
 - uuid
 
 #### Custom Format
-You can add your own custom formats by passing a `formats` object to the plugin options. See example below.
+You can add your own custom formats by passing a `formats` object to the plugin or wrapper options. See example below.
 
 ```@constraint(format: "my-custom-format")```
 
@@ -441,6 +441,8 @@ const formats = {
     throw new GraphQLError('Value must be foo')
   }
 };
+// Wrapper
+constraintDirective({ formats })(schema)
 
 // Envelop
 createEnvelopQueryValidationPlugin({ formats })

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,8 @@ export class QueryValidationVisitor {
 /**
  * Schema transformer which adds custom types performing validations based on the @constraint directives.
  */
-export function constraintDirective () : (schema: GraphQLSchema) => GraphQLSchema;
+export function constraintDirective (directiveOptions?: directiveOptions) : (schema: GraphQLSchema) => GraphQLSchema;
+interface directiveOptions implements pluginOptions {}
 
 interface DocumentationOptions {
     /** Header for the constraints documentation block in the field or argument description */

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const { getDirective, mapSchema, MapperKind } = require('@graphql-tools/utils')
 const { getConstraintTypeObject, getScalarType } = require('./lib/type-utils')
 const { constraintDirectiveTypeDefs, constraintDirectiveTypeDefsObj } = require('./lib/type-defs')
 
-function constraintDirective () {
+function constraintDirective (options = {}) {
   const constraintTypes = {}
 
   function getConstraintType (fieldName, type, notNull, directiveArgumentMap, list, listNotNull) {
@@ -43,7 +43,7 @@ function constraintDirective () {
     const key = Symbol.for(uniqueTypeName)
     let constraintType = constraintTypes[key]
     if (constraintType) return constraintType
-    constraintType = getConstraintTypeObject(fieldName, type, uniqueTypeName, directiveArgumentMap)
+    constraintType = getConstraintTypeObject(fieldName, type, uniqueTypeName, directiveArgumentMap, options)
     if (notNull) {
       constraintType = new GraphQLNonNull(constraintType)
     }

--- a/lib/type-utils.js
+++ b/lib/type-utils.js
@@ -10,13 +10,15 @@ const {
 const { ConstraintStringType, validate: validateStringFn } = require('../scalars/string')
 const { ConstraintNumberType, validate: validateNumberFn } = require('../scalars/number')
 
-function getConstraintTypeObject (fieldName, type, uniqueTypeName, directiveArgumentMap) {
+function getConstraintTypeObject (fieldName, type, uniqueTypeName, directiveArgumentMap, directiveOptions = {}) {
   if (type === GraphQLString || type === GraphQLID) {
+    const options = { pluginOptions: directiveOptions }
     return new ConstraintStringType(
       fieldName,
       uniqueTypeName,
       type,
-      directiveArgumentMap
+      directiveArgumentMap,
+      options
     )
   } else if (type === GraphQLFloat || type === GraphQLInt) {
     return new ConstraintNumberType(

--- a/test/setup-schema-wrapper.js
+++ b/test/setup-schema-wrapper.js
@@ -14,7 +14,7 @@ module.exports = async function ({ typeDefs, formatError, resolvers, schemaCreat
     schema = schemaCreatedCallback(schema)
   }
 
-  schema = constraintDirective()(schema)
+  schema = constraintDirective(pluginOptions)(schema)
 
   const app = express()
   const server = new ApolloServer({


### PR DESCRIPTION
Enables passing custom formats into the schema wrapper similar to the plugins.