### PR TITLE
feat: support `errorMessage` property in constraint directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,10 @@ Restrict array/List to a minimum length
 ```@constraint(maxItems: 3)```
 Restrict array/List to a maximum length
 
+#### errorMessage
+```@constraint(minLength: 3, errorMessage: "Title must be at least 3 characters")```
+When validation fails, return this custom message instead of the default. Applies to all constraint types (string, number, array size).
+
 ### ConstraintDirectiveError
 Each validation error throws a `ConstraintDirectiveError`. Combined with a formatError function, this can be used to customise error messages.
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function constraintDirective () {
                   type.name
                 }_${notNull ? 'NotNull_' : ''}` +
                 Object.entries(directiveArgumentMap)
+                  .filter(([key]) => key !== 'errorMessage')
                   .map(([key, value]) => {
                     if (
                       key === 'min' ||
@@ -137,7 +138,7 @@ function constraintDirectiveDocumentation (options) {
     fieldConfig.description += HEADER + '\n'
 
     Object.entries(directiveArgumentMap).forEach(([key, value]) => {
-      if (key === 'uniqueTypeName') return
+      if (key === 'uniqueTypeName' || key === 'errorMessage') return
       fieldConfig.description += `* ${DESCRIPTINS_MAP[key] ? DESCRIPTINS_MAP[key] : key}: \`${value}\`\n`
     })
 

--- a/lib/query-validation-visitor.js
+++ b/lib/query-validation-visitor.js
@@ -161,14 +161,12 @@ function validateScalarTypeValue (context, currentQueryField, typeDefWithDirecti
     try {
       getConstraintValidateFn(st)(fieldNameForError, directiveArgumentMap, value, options)
     } catch (e) {
-      let error
-
-      if (variableName) {
-        error = new ValidationError(fieldNameForError, `Variable "$${variableName}" got invalid value ${valueDelim}${value}${valueDelim}${errMessageAt}. ` + e.message, e.context)
-      } else {
-        error = new ValidationError(fieldNameForError, `Argument "${argName}" of "${currentQueryField.name.value}" got invalid value ${valueDelim}${value}${valueDelim}${errMessageAt}. ` + e.message, e.context)
-      }
-
+      const message = directiveArgumentMap.errorMessage || (
+        variableName
+          ? `Variable "$${variableName}" got invalid value ${valueDelim}${value}${valueDelim}${errMessageAt}. ` + e.message
+          : `Argument "${argName}" of "${currentQueryField.name.value}" got invalid value ${valueDelim}${value}${valueDelim}${errMessageAt}. ` + e.message
+      )
+      const error = new ValidationError(fieldNameForError, message, e.context)
       error.originalError = e
       context.reportError(error)
     }
@@ -205,14 +203,16 @@ function validateArrayTypeValue (context, valueTypeDef, typeDefWithDirective, va
       errMessageBase = `Argument "${argName}" of "${currentField.name.value}" `
     }
 
+    const defaultMinItemsMessage = errMessageBase + `must be at least ${directiveArgumentMap.minItems} in length`
+    const defaultMaxItemsMessage = errMessageBase + `must be no more than ${directiveArgumentMap.maxItems} in length`
     if (directiveArgumentMap.minItems && (!value || value.length < directiveArgumentMap.minItems)) {
       context.reportError(new ValidationError(iFieldNameFull,
-        errMessageBase + `must be at least ${directiveArgumentMap.minItems} in length`,
+        directiveArgumentMap.errorMessage || defaultMinItemsMessage,
         [{ arg: 'minItems', value: directiveArgumentMap.minItems }]))
     }
     if (directiveArgumentMap.maxItems && value && value.length > directiveArgumentMap.maxItems) {
       context.reportError(new ValidationError(iFieldNameFull,
-        errMessageBase + `must be no more than ${directiveArgumentMap.maxItems} in length`,
+        directiveArgumentMap.errorMessage || defaultMaxItemsMessage,
         [{ arg: 'maxItems', value: directiveArgumentMap.maxItems }]))
     }
 

--- a/lib/type-defs.js
+++ b/lib/type-defs.js
@@ -29,6 +29,9 @@ const constraintDirectiveTypeDefs = /* GraphQL */`
     minItems: Int
     maxItems: Int
 
+    # Custom error message when validation fails
+    errorMessage: String
+
     # Shared for Schema wrapper
     uniqueTypeName: String
 
@@ -88,6 +91,11 @@ const constraintDirectiveTypeDefsObj = new GraphQLDirective({
     },
     maxItems: {
       type: GraphQLInt
+    },
+
+    // Custom error message when validation fails
+    errorMessage: {
+      type: GraphQLString
     },
 
     // Shared for Schema wrapper

--- a/scalars/number.js
+++ b/scalars/number.js
@@ -35,32 +35,36 @@ function divisible (a, b) {
   return a % b < eps || a % b > b - eps
 }
 
+function getMessage (args, defaultMessage) {
+  return args.errorMessage || defaultMessage
+}
+
 function validate (fieldName, args, value) {
   if (args.min !== undefined && value < args.min) {
     throw new ValidationError(fieldName,
-      `Must be at least ${args.min}`,
+      getMessage(args, `Must be at least ${args.min}`),
       [{ arg: 'min', value: args.min }])
   }
   if (args.max !== undefined && value > args.max) {
     throw new ValidationError(fieldName,
-      `Must be no greater than ${args.max}`,
+      getMessage(args, `Must be no greater than ${args.max}`),
       [{ arg: 'max', value: args.max }])
   }
 
   if (args.exclusiveMin !== undefined && value <= args.exclusiveMin) {
     throw new ValidationError(fieldName,
-      `Must be greater than ${args.exclusiveMin}`,
+      getMessage(args, `Must be greater than ${args.exclusiveMin}`),
       [{ arg: 'exclusiveMin', value: args.exclusiveMin }])
   }
   if (args.exclusiveMax !== undefined && value >= args.exclusiveMax) {
     throw new ValidationError(fieldName,
-      `Must be less than ${args.exclusiveMax}`,
+      getMessage(args, `Must be less than ${args.exclusiveMax}`),
       [{ arg: 'exclusiveMax', value: args.exclusiveMax }])
   }
 
   if (args.multipleOf !== undefined && divisible(value, args.multipleOf) === false) {
     throw new ValidationError(fieldName,
-      `Must be a multiple of ${args.multipleOf}`,
+      getMessage(args, `Must be a multiple of ${args.multipleOf}`),
       [{ arg: 'multipleOf', value: args.multipleOf }])
   }
 }

--- a/scalars/string.js
+++ b/scalars/string.js
@@ -32,45 +32,49 @@ class ConstraintStringType extends GraphQLScalarType {
   }
 }
 
+function getMessage (args, defaultMessage) {
+  return args.errorMessage || defaultMessage
+}
+
 function validate (fieldName, args, value, options = {}) {
   if (args.minLength && !isLength(value, { min: args.minLength })) {
     throw new ValidationError(fieldName,
-      `Must be at least ${args.minLength} characters in length`,
+      getMessage(args, `Must be at least ${args.minLength} characters in length`),
       [{ arg: 'minLength', value: args.minLength }])
   }
   if (args.maxLength && !isLength(value, { max: args.maxLength })) {
     throw new ValidationError(fieldName,
-      `Must be no more than ${args.maxLength} characters in length`,
+      getMessage(args, `Must be no more than ${args.maxLength} characters in length`),
       [{ arg: 'maxLength', value: args.maxLength }])
   }
 
   if (args.startsWith && !value.startsWith(args.startsWith)) {
     throw new ValidationError(fieldName,
-      `Must start with ${args.startsWith}`,
+      getMessage(args, `Must start with ${args.startsWith}`),
       [{ arg: 'startsWith', value: args.startsWith }])
   }
 
   if (args.endsWith && !value.endsWith(args.endsWith)) {
     throw new ValidationError(fieldName,
-      `Must end with ${args.endsWith}`,
+      getMessage(args, `Must end with ${args.endsWith}`),
       [{ arg: 'endsWith', value: args.endsWith }])
   }
 
   if (args.contains && !contains(value, args.contains)) {
     throw new ValidationError(fieldName,
-      `Must contain ${args.contains}`,
+      getMessage(args, `Must contain ${args.contains}`),
       [{ arg: 'contains', value: args.contains }])
   }
 
   if (args.notContains && contains(value, args.notContains)) {
     throw new ValidationError(fieldName,
-      `Must not contain ${args.notContains}`,
+      getMessage(args, `Must not contain ${args.notContains}`),
       [{ arg: 'notContains', value: args.notContains }])
   }
 
   if (args.pattern && !new RegExp(args.pattern).test(value)) {
     throw new ValidationError(fieldName,
-      `Must match ${args.pattern}`,
+      getMessage(args, `Must match ${args.pattern}`),
       [{ arg: 'pattern', value: args.pattern }])
   }
 
@@ -81,7 +85,7 @@ function validate (fieldName, args, value, options = {}) {
 
     if (!formatter) {
       throw new ValidationError(fieldName,
-        `Invalid format type ${args.format}`,
+        getMessage(args, `Invalid format type ${args.format}`),
         [{ arg: 'format', value: args.format }])
     }
 
@@ -89,7 +93,7 @@ function validate (fieldName, args, value, options = {}) {
       formatter(value, args) // Will throw if invalid
     } catch (e) {
       throw new ValidationError(fieldName,
-        e.message,
+        getMessage(args, e.message),
         [{ arg: 'format', value: args.format }])
     }
   }

--- a/test/argument.test.js
+++ b/test/argument.test.js
@@ -73,7 +73,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query, variables: { size: 100 } })
 
-        // console.log('Body: ' + JSON.stringify(body))
         isStatusCodeError(statusCode, implType)
         strictEqual(body.errors[0].message,
           'Variable "$size" got invalid value 100' + valueByImplType(implType, '; Expected type "size_Int_max_3"') + '. Must be no greater than 3')
@@ -96,7 +95,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query: queryTwoVariables, variables: { size: 4, sizeAuthors: 5 } })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         const errors = unwrapMoreValidationErrors(body.errors)
         strictEqual(errors[0].message,
@@ -215,7 +213,6 @@ module.exports.test = function (setup, implType) {
           .send({ query: queryFailing })
 
         isStatusCodeError(statusCode, implType)
-        // console.log(body.errors)
         strictEqual(body.errors[0].message,
           valueByImplType(implType,
             'Expected value of type "size_Int_NotNull_max_3!", found 100; Must be no greater than 3',
@@ -230,7 +227,6 @@ module.exports.test = function (setup, implType) {
           .send({ query: queryDeeperFailing })
 
         isStatusCodeError(statusCode, implType)
-        // console.log(body.errors)
         strictEqual(body.errors[0].message,
           valueByImplType(implType,
             'Expected value of type "size_Int_max_4", found 5; Must be no greater than 4',
@@ -243,7 +239,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query: queryFailingTwoTimes })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         const errors = unwrapMoreValidationErrors(body.errors)
         strictEqual(errors[0].message,

--- a/test/array-structures.test.js
+++ b/test/array-structures.test.js
@@ -98,7 +98,6 @@ module.exports.test = function (setup, implType) {
             .set('Accept', 'application/json')
             .send({ query, variables: { input: { authors: [{ name: 'asdsdd', age: [5, 2] }, { name: 'fdgt', age: [1, 5] }] } } })
 
-          // console.log(body)
           isStatusCodeError(statusCode, implType)
           const errors = unwrapMoreValidationErrors(body.errors)
           strictEqual(
@@ -351,7 +350,6 @@ module.exports.test = function (setup, implType) {
             .set('Accept', 'application/json')
             .send({ query, variables: { input: [{ title: 'asdfrs', authors: [{ name: 'dfgds' }, { name: 'ytyuyd' }] }, { title: 'hgfgh', authors: [{ name: 'rertfs' }] }] } })
 
-          // console.log(body)
           isStatusCodeError(statusCode, implType)
           const errors = unwrapMoreValidationErrors(body.errors)
           strictEqual(
@@ -413,7 +411,6 @@ module.exports.test = function (setup, implType) {
             .set('Accept', 'application/json')
             .send({ query })
 
-          // console.log(body)
           isStatusCodeError(statusCode, implType)
           const errors = unwrapMoreValidationErrors(body.errors)
           strictEqual(

--- a/test/fragment-inline.test.js
+++ b/test/fragment-inline.test.js
@@ -43,7 +43,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         strictEqual(statusCode, 200)
         deepStrictEqual(body, { data: { search: null } })
       })
@@ -68,7 +67,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         const errors = unwrapMoreValidationErrors(body.errors)
         strictEqual(
@@ -108,7 +106,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query, variables: { arg1: 5, arg2: 4 } })
 
-        // console.log(body)
         strictEqual(statusCode, 200)
         deepStrictEqual(body, { data: { search: null } })
       })
@@ -119,7 +116,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query, variables: { arg1: 4, arg2: 3 } })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         const errors = unwrapMoreValidationErrors(body.errors)
         strictEqual(

--- a/test/fragment.test.js
+++ b/test/fragment.test.js
@@ -39,7 +39,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         strictEqual(statusCode, 200)
         deepStrictEqual(body, { data: { leftComparison: null, rightComparison: null } })
       })
@@ -65,7 +64,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         strictEqual(
           body.errors[0].message,
@@ -99,7 +97,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query, variables: { arg: 5 } })
 
-        // console.log(body)
         strictEqual(statusCode, 200)
         deepStrictEqual(body, { data: { leftComparison: null, rightComparison: null } })
       })
@@ -110,7 +107,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query, variables: { arg: 4 } })
 
-        // console.log(JSON.stringify(body))
         isStatusCodeError(statusCode, implType)
         strictEqual(
           body.errors[0].message,

--- a/test/int.test.js
+++ b/test/int.test.js
@@ -946,7 +946,6 @@ module.exports.test = function (setup, implType) {
             .set('Accept', 'application/json')
             .send({ query })
 
-          // console.log(JSON.stringify(body))
           strictEqual(statusCode, 200)
           deepStrictEqual(body.errors[0], {
             message: 'Must be at least 2',

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -31,7 +31,7 @@ module.exports.test = function (setup, implType) {
 
       strictEqual(statusCode, 200)
       const directive = body.data.__schema.directives.find(v => v.name === 'constraint')
-      strictEqual(directive.args.length, 16)
+      strictEqual(directive.args.length, 17)
 
       // `uniqueTypeName` not used in the server validator based implementation
       const type = body.data.__schema.types.find(t => t.name === 'BookInput_subTitle')

--- a/test/snapshots/ws-1-1.txt
+++ b/test/snapshots/ws-1-1.txt
@@ -1,4 +1,4 @@
-directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, errorMessage: String, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
 
 type Query {
   """Query books field documented"""

--- a/test/snapshots/ws-1.txt
+++ b/test/snapshots/ws-1.txt
@@ -1,4 +1,4 @@
-directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, errorMessage: String, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
 
 type Query {
   """Query books field documented"""

--- a/test/snapshots/ws-2-2.txt
+++ b/test/snapshots/ws-2-2.txt
@@ -1,4 +1,4 @@
-directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, errorMessage: String, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
 
 type Query {
   """Query books field documented"""

--- a/test/snapshots/ws-2.txt
+++ b/test/snapshots/ws-2.txt
@@ -1,4 +1,4 @@
-directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, errorMessage: String, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
 
 type Query {
   """Query books field documented"""

--- a/test/snapshots/ws-3.txt
+++ b/test/snapshots/ws-3.txt
@@ -1,4 +1,4 @@
-directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
+directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, contains: String, notContains: String, pattern: String, format: String, min: Float, max: Float, exclusiveMin: Float, exclusiveMax: Float, multipleOf: Float, minItems: Int, maxItems: Int, errorMessage: String, uniqueTypeName: String) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION | ARGUMENT_DEFINITION
 
 type Query {
   """Query books field documented"""

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -1,5 +1,5 @@
-const { deepStrictEqual, strictEqual, ok } = require('assert')
-const { valueByImplType, formatError, isSchemaWrapperImplType, isServerValidatorRule, isServerValidatorEnvelop, isStatusCodeError, isServerValidatorApollo4 } = require('./testutils')
+const { deepStrictEqual, strictEqual } = require('assert')
+const { valueByImplType, formatError, isSchemaWrapperImplType, isServerValidatorRule, isServerValidatorEnvelop, isStatusCodeError, isServerValidatorApollo4, isValidExtensionError } = require('./testutils')
 const { GraphQLError } = require('graphql/error')
 
 module.exports.test = function (setup, implType) {
@@ -114,12 +114,7 @@ module.exports.test = function (setup, implType) {
           true,
           `Expected message to be or end with "${customMessage}", got: ${body.errors[0].message}`
         )
-        console.log(body.errors[0].extensions)
-        strictEqual(body.errors[0].extensions.code, 'BAD_USER_INPUT')
-        strictEqual(body.errors[0].extensions.field, 'input.title')
-        strictEqual(body.errors[0].extensions.context[0].arg, 'minLength')
-        strictEqual(body.errors[0].extensions.context[0].value, 3)
-        ok(Array.isArray(body.errors[0].extensions.exception.stacktrace))
+        isValidExtensionError(body.errors[0], implType)
       })
 
       if (isSchemaWrapperImplType(implType)) {

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -1,4 +1,4 @@
-const { deepStrictEqual, strictEqual } = require('assert')
+const { deepStrictEqual, strictEqual, ok } = require('assert')
 const { valueByImplType, formatError, isSchemaWrapperImplType, isServerValidatorRule, isServerValidatorEnvelop, isStatusCodeError, isServerValidatorApollo4 } = require('./testutils')
 const { GraphQLError } = require('graphql/error')
 
@@ -76,6 +76,64 @@ module.exports.test = function (setup, implType) {
             fieldName: 'title',
             context: [{ arg: 'minLength', value: 3 }]
           })
+        })
+      }
+    })
+
+    describe('#errorMessage', function () {
+      const customMessage = 'Title must be at least 3 characters'
+      before(async function () {
+        this.typeDefs = `
+      type Query {
+        books: [Book]
+      }
+      type Book {
+        title: String
+      }
+      type Mutation {
+        createBook(input: BookInput): Book
+      }
+      input BookInput {
+        title: String! @constraint(minLength: 3, errorMessage: "${customMessage}")
+      }`
+
+        this.request = await setup({ typeDefs: this.typeDefs })
+      })
+
+      it('should return custom error message when validation fails', async function () {
+        const { body, statusCode } = await this.request
+          .post('/graphql')
+          .set('Accept', 'application/json')
+          .send({ query, variables: { input: { title: 'ab' } } })
+
+        isStatusCodeError(statusCode, implType)
+        // Error may be just the custom message (visitor path) or "Variable ... ; " + customMessage (coercion path)
+
+        strictEqual(
+          body.errors[0].message === customMessage || body.errors[0].message.endsWith(customMessage),
+          true,
+          `Expected message to be or end with "${customMessage}", got: ${body.errors[0].message}`
+        )
+        console.log(body.errors[0].extensions)
+        strictEqual(body.errors[0].extensions.code, 'BAD_USER_INPUT')
+        strictEqual(body.errors[0].extensions.field, 'input.title')
+        strictEqual(body.errors[0].extensions.context[0].arg, 'minLength')
+        strictEqual(body.errors[0].extensions.context[0].value, 3)
+        ok(Array.isArray(body.errors[0].extensions.exception.stacktrace))
+      })
+
+      if (isSchemaWrapperImplType(implType)) {
+        it('should return custom error with formatError', async function () {
+          const request = await setup({ typeDefs: this.typeDefs, formatError })
+          const { body, statusCode } = await request
+            .post('/graphql')
+            .set('Accept', 'application/json')
+            .send({ query, variables: { input: { title: 'ab' } } })
+
+          strictEqual(statusCode, 400)
+          strictEqual(body.errors[0].message, customMessage)
+          strictEqual(body.errors[0].code, 'ERR_GRAPHQL_CONSTRAINT_VALIDATION')
+          strictEqual(body.errors[0].fieldName, 'title')
         })
       }
     })
@@ -1116,7 +1174,6 @@ module.exports.test = function (setup, implType) {
             .set('Accept', 'application/json')
             .send({ query, variables: { input: { title: undefined } } })
 
-          // console.log(JSON.stringify(body))
           if (isServerValidatorRule(implType)) { strictEqual(statusCode, 500) } else { isServerValidatorApollo4(implType) ? strictEqual(statusCode, 200) : strictEqual(statusCode, 400) }
           strictEqual(body.errors[0].message,
             'Variable "$input" got invalid value {}; Field "title" of required type "' + valueByImplType(implType, 'title_String_NotNull_minLength_3', 'String') + '!" was not provided.')

--- a/test/union.test.js
+++ b/test/union.test.js
@@ -46,7 +46,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         strictEqual(statusCode, 200)
         deepStrictEqual(body, { data: { items: null } })
       })
@@ -72,7 +71,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         strictEqual(statusCode, 200)
         deepStrictEqual(body, { data: { items: null } })
       })
@@ -97,7 +95,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         strictEqual(
           body.errors[0].message,
@@ -127,7 +124,6 @@ module.exports.test = function (setup, implType) {
           .set('Accept', 'application/json')
           .send({ query })
 
-        // console.log(body)
         isStatusCodeError(statusCode, implType)
         strictEqual(
           body.errors[0].message,


### PR DESCRIPTION
### Feat: Support custom error messages

This PR adds support for custom error messages when a constraint validation fails.

A new `errorMessage` argument has been added to the `@constraint` directive.

Example:
```
  input BookInput {
    title: String! @constraint(minLength: 3, errorMessage: "Title must be at least 3 characters")
  }
```

Now, when the `minLength` constraint fails, the custom error message will be returned instead of the default one.

This applies to all constraint types (string, number, array size).